### PR TITLE
A couple of small cbf_simulator edits

### DIFF
--- a/katsdpingest/conf/c8n856M32k
+++ b/katsdpingest/conf/c8n856M32k
@@ -4,7 +4,7 @@
 
 [katcp]
 #List of servers to be used for F/X engines. Comma separated list with no whitespace.
-servers_f = roach030268,roach030279,roach030265,roach030203
+servers_f = roach030268,roach030279
 servers_x = roach030284,roach030271,roach030270,roach030283
 #This is the control port to use when communicating with BORPH. By default, ROACHes use 7147.
 katcp_port = 7147
@@ -20,7 +20,7 @@ adc_type = mkdeng
 #number of frequency channels
 n_chans = 32768
 #number of antennas in the design.
-n_ants = 4
+n_ants = 2
 #fft shifting schedule in decimal. A binary '1' shifts, a zero does not.
 fft_shift = 1023
 #Number of spectra to integrate in DRAM.

--- a/katsdpingest/simulator/cbf_simulator_model.py
+++ b/katsdpingest/simulator/cbf_simulator_model.py
@@ -400,6 +400,7 @@ class K7CorrelatorModel(TestInterfaceModel):
 
     def run(self):
         while not self._stopEvent.isSet():
+            st = time.time()
             if not self._thread_paused:
                 with self._data_lock:
                     self.data = self.generate_data()
@@ -410,7 +411,7 @@ class K7CorrelatorModel(TestInterfaceModel):
                            (self.nd > 0 and 'On' or 'Off')))
                 sys.stdout.write(status)
                 sys.stdout.flush()
-            st = time.time()
+            print ' sleep: ', max(self._dump_period - (time.time() - st), 0.) 
             time.sleep(max(self._dump_period - (time.time() - st), 0.))
         self.send_stop()
         print "Correlator tx halted."

--- a/scripts/cbf_simulator.py
+++ b/scripts/cbf_simulator.py
@@ -81,9 +81,9 @@ def parse_opts(argv):
 
 def setup_standalone(server, model):
     model.set_mode('c8n856M32k',mode_delay=0)
-    for i in [62]+[63]*7:
+    for cbf_ant, ant in zip([0,1],[62,63]):    
         for ch,pol in zip(['x', 'y'], ['h', 'v']):
-            model.set_antenna_mapping('%d%s' %(i, ch), 'm%03d%s' %(i, pol))
+            model.set_antenna_mapping('%d%s' %(cbf_ant, ch), 'm%03d%s' %(ant, pol))
 
 if __name__ == '__main__':
     opts, args = parse_opts(sys.argv)


### PR DESCRIPTION
@sratcliffe @ludwigschwardt 

katsdpingest/simulator/cbf_simulator_model.py
- fixed timing bug, where delay time was calculated by subtracting the
  time directly before the delay.

katsdpingest/conf/c8n856M32k
- edited the conf file to use two antennas (and hence two roaches,
  servers_f)

scripts/cbf_simulator.py
- edited setup_standalone to map the correlator bls_ordering format
  (e.g. 0x) to the format required for the hdf5 file (e.g. 62h)
