### PR TITLE
Sleep when thread is paused to avoid busy loop

### DIFF
--- a/katsdpingest/simulator/cbf_simulator_model.py
+++ b/katsdpingest/simulator/cbf_simulator_model.py
@@ -403,7 +403,6 @@ class K7CorrelatorModel(TestInterfaceModel):
         while not self._stopEvent.isSet():
             st = time.time()
             if not self._thread_paused:
-                st = time.time()
                 with self._data_lock:
                     self.data = self.generate_data()
                 self.send_dump()
@@ -414,7 +413,7 @@ class K7CorrelatorModel(TestInterfaceModel):
                            (self.nd > 0 and 'On' or 'Off')))
                 sys.stdout.write(status)
                 sys.stdout.flush()
-                time.sleep(max(self._dump_period - (time.time() - st), 0.))
+            time.sleep(max(self._dump_period - (time.time() - st), 0.))
         self.send_stop()
         print "Correlator tx halted."
 


### PR DESCRIPTION
During the refactoring between Laura and Simon, the time.sleep command
inadvertently got indented and thereafter only happened when the CBF
thread was unpaused and not when it was paused. This causes CPU usage
to spike due to a busy loop while the simulator has not started yet,
and then the CPU usage drops when the simulator actually produces data.
Revert back to the original setup last found in 3d809dc1 while keeping
Simon's additional debug output.

Reviewers: @LauraRichter @sratcliffe 
