### PR TITLE
Fix spead metadata packet issue

### DIFF
--- a/katsdpingest/simulator/cbf_spead_model.py
+++ b/katsdpingest/simulator/cbf_spead_model.py
@@ -88,7 +88,8 @@ class DBE7SpeadData(object):
 
     def spead_labelling_issue(self):
         tx=self.tx
-        ig=self.data_ig
+        ig=spead.ItemGroup()
+
 #        ig.add_item(name="bls_ordering",id=0x100C,
 #            description="The output ordering of the baselines from each X engine. Packed as a pair of unsigned integers, ant1,ant2 where ant1 < ant2.",
 #            shape=[self.config['n_bls'],2],fmt=spead.mkfmt(('u',16)),


### PR DESCRIPTION
In tandem with a bug introduced in PySPEAD in Feb 2014 (commit 6557167)
this causes the CBF ingest thread to crash upon receiving the labelling
metadata packet. Instead of starting from an empty ItemGroup, this code
reused the data_ig, which already contained the 'timestamp' and 'xeng_raw'
items. While these have already been sent in the first metadata packet,
the PySPEAD bug caused their descriptors to be resent, thereby resetting
the 'timestamp' value to None which then crashes upon ig['timestamp']
access in ingest_threads.py. The solution (apart from fixing PySPEAD)
is to start from a fresh ItemGroup to avoid this.

@sratcliffe 
