### PR TITLE
Move script_log from ingest to cam2spead

### DIFF
--- a/katsdpingest/cam2spead.py
+++ b/katsdpingest/cam2spead.py
@@ -227,6 +227,12 @@ class Cam2SpeadDeviceServer(DeviceServer):
             self.ig.add_item(name=name, id=spead_id, description='Observation parameters',
                             shape=-1, fmt=spead.mkfmt(('s', 8)), init_val='')
             spead_id += 1
+        name = 'obs_script_log'
+        if name not in self.ig.keys():
+            logger.debug("Registering virtual sensor %r with SPEAD id 0x%x" % (name, spead_id))
+            self.ig.add_item(name=name, id=spead_id, description='Observation script log',
+                            shape=-1, fmt=spead.mkfmt(('s', 8)), init_val='')
+            spead_id += 1
         SensorBridge.next_available_spead_id = spead_id
         return self.ig.get_heap()
 
@@ -416,4 +422,13 @@ class Cam2SpeadDeviceServer(DeviceServer):
         if name not in self.destinations:
             return ("fail", "Unknown SPEAD stream %r" % (name,))
         self.update_sensor('obs_params', ' '.join((key, value)))
+        return ("ok",)
+
+    @request(Str(), Str())
+    @return_reply()
+    def request_script_log(self, req, name, log):
+        """Add an entry to the script log on the desired SPEAD stream."""
+        if name not in self.destinations:
+            return ("fail", "Unknown SPEAD stream %r" % (name,))
+        self.update_sensor('obs_script_log', log)
         return ("ok",)

--- a/katsdpingest/ingest_threads.py
+++ b/katsdpingest/ingest_threads.py
@@ -83,7 +83,6 @@ class CBFIngest(threading.Thread):
         self.cbf_component = self.model.components[self.cbf_name]
         self.cbf_attr = self.cbf_component.attributes
 
-        self._log_idx = 0
         self._process_log_idx = 0
         self._my_sensors = my_sensors
         self.pkt_sensor = self._my_sensors['packets-captured']
@@ -168,13 +167,6 @@ class CBFIngest(threading.Thread):
             for tx in self.sdisp_ips.itervalues():
                 mdata = copy.deepcopy(self._sd_metadata)
                 tx.send_heap(mdata)
-
-    def write_log(self, log):
-        """Write a log value directly into the current hdf5 file."""
-        if self._log_idx > 0:
-            self.h5_file['/History/script_log'].resize(self._log_idx+1,axis=0)
-        self.h5_file['/History/script_log'][self._log_idx] = (time.time(), log)
-        self._log_idx += 1
 
     def write_process_log(self, process, args, revision):
         """Write an entry into the process log."""

--- a/katsdpingest/telescope_model.py
+++ b/katsdpingest/telescope_model.py
@@ -360,5 +360,5 @@ class Observation(TelescopeComponent):
     def __init__(self, *args, **kwargs):
         super(Observation, self).__init__(*args, **kwargs)
         self._critical_sensors = ['label','params']
+        self._std_sensors = ['script_log']
         self._build()
-

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -242,17 +242,6 @@ class IngestDeviceServer(DeviceServer):
 
     @request(Str())
     @return_reply(Str())
-    def request_script_log(self, req, log):
-        """Add an entry to the script log."""
-        if self.cbf_thread is None: return ("fail","No active capture thread. Please start one using capture_start")
-        self._my_sensors["script-log"].set_value(log)
-        self.cbf_thread.write_log(log)
-        smsg = "Script log entry added (%s)" % log
-        logger.info(smsg)
-        return ("ok", smsg)
-
-    @request(Str())
-    @return_reply(Str())
     def request_drop_sdisp_ip(self, req, ip):
         """Drop an IP address from the internal list of signal display data recipients."""
         if self.cbf_thread is not None:


### PR DESCRIPTION
Update the script log via a (virtual) observation sensor on cam2spead
instead of via a special call to the CBF ingest thread. The rationale
is that the script log is something that produces events while the
observation script is running similar to other CAM sensors. This ensures
that third-party users will get their script_log fix via SPEAD as well.
The script_log becomes an optional sensor of the obs telescope component.

To accommodate this some refactoring was done to the sensor update
mechanism so that real and virtual KATCP sensors go through the same
method (Cam2SpeadDeviceServer.update_sensor). This avoids further
code duplication and improves debugging.

Reviewers: @sratcliffe @brickZA 
