### PR TITLE
Improve thread safety of sdisp IP store

### DIFF
--- a/katsdpingest/ingest_threads.py
+++ b/katsdpingest/ingest_threads.py
@@ -124,7 +124,9 @@ class CBFIngest(threading.Thread):
         #    logger.debug("Sending metadata heartbeat...")
         #    self.send_sd_metadata()
 
-        for tx in self.sdisp_ips.itervalues():
+        # Revisit this in Python 3, as .values() will still be a view on dict
+        # We need a lock to be sure dict is not modified during iteration
+        for tx in self.sdisp_ips.values():
             tx.send_heap(data)
 
         self._sd_count += 1
@@ -164,7 +166,8 @@ class CBFIngest(threading.Thread):
     def send_sd_metadata(self):
         self._sd_metadata = self._update_sd_metadata()
         if self._sd_metadata is not None:
-            for tx in self.sdisp_ips.itervalues():
+            # Revisit this in Python 3, as .values() will still be a view on dict
+            for tx in self.sdisp_ips.values():
                 mdata = copy.deepcopy(self._sd_metadata)
                 tx.send_heap(mdata)
 

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -180,7 +180,7 @@ class IngestDeviceServer(DeviceServer):
 
         self._my_sensors["capture-active"].set_value(1)
          # add in existing signal display recipients...
-        for (ip,port) in self.sdisp_ips.iteritems():
+        for (ip,port) in self.sdisp_ips.items():
             self.cbf_thread.add_sdisp_ip(ip,port)
         smsg =  "Capture initialised at %s" % time.ctime()
         logger.info(smsg)


### PR DESCRIPTION
The capture thread iterates over the sdisp_ips dict when transmitting signal
display data. On the other hand, the KATCP DeviceServer thread asynchronously
adds and removes IPs from this dict when the appropriate request is handled.
This can cause a RuntimeError ("dictionary changed size during iteration").
By using .values() instead of .itervalues() the tx objects are first copied
into a list (at least in Python 2) which is then safe to iterate over. In
Python 3 this needs revisiting (by e.g. explicitly putting values in a list
or adding a proper lock).

Reviewer: @mattieudv 
