### PR TITLE
Put requirements for katsdpsigproc and PySPEAD into requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ python:
 before_install: sudo apt-get install -qq libhdf5-serial-dev libblas-dev gfortran liblapack-dev
 # command to install dependencies
 install:
-  - "git clone -q --depth 1 git@github.com:ska-sa/PySPEAD"
-  - "(cd PySPEAD && python ./setup.py install)"
-  - "git clone -q --depth 1 git@github.com:ska-sa/katsdpsigproc"
-  - "(cd katsdpsigproc && python ./setup.py install)"
   - "pip install -r requirements.txt --use-mirrors"
 # command to run tests
 script: nosetests katsdpingest.test.test_telescope_model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 numpy
 h5py
-spead
+git+https://github.com/ska-sa/PySPEAD
 iniparse
 blinker
 scikits.fitting
 katcp==0.5.2
-katsdpsigproc
+git+ssh://git@github.com/ska-sa/katsdpsigproc
 mock


### PR DESCRIPTION
This addresses @mattieudv's concerns about it being messy to have information about which packages are required split between requirements.txt and .travis.yml.

I've specified https for PySPEAD but ssh for katsdpsigproc because the former is a public repo.

@ludwigschwardt, please review.
