### PR TITLE
Use explicit FMA, since AMD doesn't automatically use it

### DIFF
--- a/katsdpingest/ingest_kernels/accum.mako
+++ b/katsdpingest/ingest_kernels/accum.mako
@@ -9,8 +9,8 @@
 DEVICE_FN void accum_vis(GLOBAL float2 *out, float2 value, float weight)
 {
     float2 sum = *out;
-    sum.x += value.x * weight;
-    sum.y += value.y * weight;
+    sum.x = fma(value.x, weight, sum.x);
+    sum.y = fma(value.y, weight, sum.y);
     *out = sum;
 }
 


### PR DESCRIPTION
@sratcliffe: here's a trival two-line change for you to review. It makes the kernel quite a bit faster on AMD.
