### PR TITLE
Last pieces of first SPEAD output from ingest

### DIFF
--- a/katsdpingest/ingest_threads.py
+++ b/katsdpingest/ingest_threads.py
@@ -481,6 +481,7 @@ class CBFIngest(threading.Thread):
         #### Stop received.
 
         self.logger.info("CBF ingest complete at %f" % time.time())
+        tx_spectral.end()
         if self.proc is not None:   # Could be None if no heaps arrived
             self.logger.debug("\nProcessing Blocks\n=================\n")
             for description in self.proc.descriptions():


### PR DESCRIPTION
You merged before I had a chance to push this. capture_done just sends a stop packet to self, so there is no difference in how natural stop versus capture_done is handled.
