### PR TITLE
Replace virtual noise diode sensor with real one

### DIFF
--- a/katsdpingest/cam2spead.py
+++ b/katsdpingest/cam2spead.py
@@ -336,12 +336,3 @@ class Cam2SpeadDeviceServer(DeviceServer):
             return ("fail", "Unknown SPEAD stream %r" % (name,))
         self.update_sensor('obs_script_log', log)
         return ("ok",)
-
-    @request(Str(), Str(), Timestamp(), Bool())
-    @return_reply()
-    def request_set_nd_sensor(self, req, name, receptor, timestamp, value):
-        """Set a noise diode flag on the desired SPEAD stream."""
-        if name not in self.destinations:
-            return ("fail", "Unknown SPEAD stream %r" % (name,))
-        self.update_sensor(receptor + '_noise_source', value, timestamp)
-        return ("ok",)

--- a/katsdpingest/conf/rts_sensors.csv
+++ b/katsdpingest/conf/rts_sensors.csv
@@ -5,14 +5,14 @@ m062_pos_actual_scan_elev, Actual elevation after scan offset, deg, float
 m062_pos_request_scan_azim, Requested azimuth after scan offset, deg, float
 m062_pos_request_scan_elev, Requested elevation after scan offset, deg, float
 m062_target, Current target, , string
-m062_noise_source, Noise diode flag, , boolean
+m062_dig_noise_diode, Noise diode flag, , boolean
 m063_activity, Combined state of the antenna proxy, , discrete
 m063_pos_actual_scan_azim, Actual azimuth after scan offset, deg, float
 m063_pos_actual_scan_elev, Actual elevation after scan offset, deg, float
 m063_pos_request_scan_azim, Requested azimuth after scan offset, deg, float
 m063_pos_request_scan_elev, Requested elevation after scan offset, deg, float
 m063_target, Current target, , string
-m063_noise_source, Noise diode flag, , boolean
+m063_dig_noise_diode, Noise diode flag, , boolean
 data_rts_auto_delay_enabled, Whether automatic delay parameter sending is on., , boolean
 data_rts_target, Current target, , string
 anc_asc_air_pressure, Air pressure, mbar, float


### PR DESCRIPTION
Instead of calling cam2spead to set the virtual nd sensor (via the data
proxy), rather use the newly provided digitiser sensor (dig.noise-diode).
The new sensor is not much better than the virtual one, but requires
less work from SP + CAM.

@mauch, have a look at this if you can.
