### PR TITLE
Rewrite Dockerfiles based on docker-base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,3 @@ WORKDIR /home/kat
 EXPOSE 2040
 EXPOSE 7147/udp
 EXPOSE 7148/udp
-ENTRYPOINT ["/usr/local/bin/ingest.py"]

--- a/Dockerfile.simulator
+++ b/Dockerfile.simulator
@@ -31,4 +31,4 @@ USER kat
 WORKDIR /home/kat
 
 EXPOSE 2041
-ENTRYPOINT ["/usr/local/bin/cbf_data_simulator.py", "--standalone"]
+CMD ["/usr/local/bin/cbf_data_simulator.py", "--standalone"]


### PR DESCRIPTION
Apart from having less to do, there are a few changes:
- ENTRYPOINT used - so katsdpcontroller will need a change to not pass
  the script filename. This ensures that the script is run directly
  rather that via a shell. It also avoid having to encode the filename
  into katsdpcontroller.
- Added EXPOSE for the UDP ports

@sratcliffe, can you review this at the same time as the [katsdpcontroller PR](https://github.com/ska-sa/katsdpcontroller/pull/14)?
