### PR TITLE
Remove system param from tbuild

### DIFF
--- a/scripts/cam2spead.py
+++ b/scripts/cam2spead.py
@@ -69,7 +69,7 @@ if opts.fake_cam:
         logger.warning('No attributes were returned by fake CAM server %s:%d' %
                        (opts.fake_cam_host, opts.fake_cam_port))
 else:
-    kat = katcorelib.tbuild(system=opts.system)
+    kat = katcorelib.tbuild()
     all_sensors = kat.sensors
     antennas = kat.katconfig.array_conf.antennas
     attributes = dict([('%s_description' % (ant,), antennas[ant].observer.description)


### PR DESCRIPTION
@ludwigschwardt : We might need to merge this during integration.

We have removed that passing around of the system parameter everywhere since we cannot build a system outside of that system. We now autoconfigure by reading the system from the katconf source.
