### PR TITLE
Add indexer position and RX serial number sensors

### DIFF
--- a/katsdpingest/conf/rts_sensors.csv
+++ b/katsdpingest/conf/rts_sensors.csv
@@ -6,6 +6,11 @@ m062_pos_request_scan_azim, Requested azimuth after scan offset, deg, float
 m062_pos_request_scan_elev, Requested elevation after scan offset, deg, float
 m062_target, Current target, , string
 m062_dig_noise_diode, Noise diode flag, , boolean
+m062_rsc_rxl_serial_number, L-band RX Cryostat serial number, serial_number, integer
+m062_rsc_rxs_serial_number, S-band RX Cryostat serial number, serial_number, integer
+m062_rsc_rxu_serial_number, UHF-band RX Cryostat serial number, serial_number, integer
+m062_rsc_rxx_serial_number, X-band RX Cryostat serial number, serial_number, integer
+m062_ap_indexer_position, The current receiver indexer position as a discrete mapped to the receiver band it is at., , discrete
 m063_activity, Combined state of the antenna proxy, , discrete
 m063_pos_actual_scan_azim, Actual azimuth after scan offset, deg, float
 m063_pos_actual_scan_elev, Actual elevation after scan offset, deg, float
@@ -13,6 +18,11 @@ m063_pos_request_scan_azim, Requested azimuth after scan offset, deg, float
 m063_pos_request_scan_elev, Requested elevation after scan offset, deg, float
 m063_target, Current target, , string
 m063_dig_noise_diode, Noise diode flag, , boolean
+m063_rsc_rxl_serial_number, L-band RX Cryostat serial number, serial_number, integer
+m063_rsc_rxs_serial_number, S-band RX Cryostat serial number, serial_number, integer
+m063_rsc_rxu_serial_number, UHF-band RX Cryostat serial number, serial_number, integer
+m063_rsc_rxx_serial_number, X-band RX Cryostat serial number, serial_number, integer
+m063_ap_indexer_position, The current receiver indexer position as a discrete mapped to the receiver band it is at., , discrete
 data_rts_auto_delay_enabled, Whether automatic delay parameter sending is on., , boolean
 data_rts_target, Current target, , string
 anc_asc_air_pressure, Air pressure, mbar, float


### PR DESCRIPTION
These sensors will be used down the line to identify the appropriate noise
diode model to use for the observation.

Reviewer: @sratcliffe 
