### PR TITLE
Rename k7-accumulation-length to be without k7

### DIFF
--- a/katsdpingest/simulator/cbf_simulator.py
+++ b/katsdpingest/simulator/cbf_simulator.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(log_name)
 #
 # cycle_nd -> Should go to sim interface, actually listen to rfe3 simulator?
 # fire_nd -> Should go to sim interface, actually listen to rfe3 simulator?
-# poco_accumulation_length -> k7_accumulation_length
+# poco_accumulation_length -> accumulation_length
 # poco_gain -> k7_gain
 # pointing_az -> Should go to sim interface, interaction with other simulators?
 # pointing_el -> Should go to sim interface, interaction with other simulators?
@@ -40,7 +40,7 @@ logger = logging.getLogger(log_name)
 # Requests to add:
 #
 # capture_list -> DONE
-# k7_accumulation_length -> DONE
+# accumulation_length -> DONE
 # k7_adc_snap_shot -> DONE
 # k7_delay -> DONE, stubbily
 # k7_frequency_select TODO
@@ -199,8 +199,8 @@ class DBE7DeviceServer(SensorSignalDeviceServer):
 
     @request(Str())
     @return_reply(Str())
-    def request_k7_accumulation_length(self, req, period):
-        """Set the accumulation length. (?k7-accumlation-length accumulation-period)"""
+    def request_accumulation_length(self, req, period):
+        """Set the accumulation length. (?accumlation-length accumulation-period)"""
         self._model.set_dump_period(float(period) / 1000.0)
         dump_period = self._model.get_dump_period()
         time.sleep(dump_period)

--- a/katsdpingest/simulator/test/test_cbf.py
+++ b/katsdpingest/simulator/test/test_cbf.py
@@ -140,7 +140,7 @@ EXPECTED_REQUEST_LIST = [
     ('capture-stop', 'For compatibility with dbe_proxy. Does nothing :).'),
     ('cycle-nd', 'Fire the noise diode with the requested duty cycle. Set to 0 to disable.'),
     ('fire-nd', 'Insert noise diode spike into output data.'),
-    ('k7-accumulation-length', 'Set the accumulation length. (?k7-accumlation-length accumulation-period)'),
+    ('accumulation-length', 'Set the accumulation length. (?accumlation-length accumulation-period)'),
     ('k7-adc-snap-shot', 'retrieve an adc snapshot (?k7-adc-snap-shot [pps|now] threshold input+)'),
     ('k7-delay', 'set the delay and fringe correction (?k7-delay board-input time delay-value delay-rate fringe-offset fringe-rate)'),
     ('k7-frequency-select', 'select a frequency for fine channelisation (?k7-frequency-select center-frequency)'),
@@ -187,8 +187,8 @@ class TestDbeKat7(unittest.TestCase, SimulatorTestMixin):
         self.client.assert_request_succeeds("label-input", "0x", "ant1H", args_equal=["ant1H"])
         self.client.assert_request_succeeds("label-input", "0x", args_equal=["ant1H"])
 
-    def test_k7_accumulation_length(self):
-        self.client.assert_request_succeeds("k7-accumulation-length", 1.0)
+    def test_accumulation_length(self):
+        self.client.assert_request_succeeds("accumulation-length", 1.0)
 
     @unittest.skip
     # Request not currently implemented

--- a/scripts/tests/test_cbf_simulator.py
+++ b/scripts/tests/test_cbf_simulator.py
@@ -152,7 +152,7 @@ class test_CorrelatorData_c16n400M1k(ModuleSetupTestCase):
 
     def test_data(self):
         # Set dump rate to 100ms to speed stuff up
-        self.sim.katcp_req('k7-accumulation-length', 100)
+        self.sim.katcp_req('accumulation-length', 100)
         # Set test target at az 165, el 45 deg with flux of 200
         self.sim.katcp_req('test-target', '165.', '45.', '200.')
         # Point 'antenna' away from test target


### PR DESCRIPTION
This matches the CBF simulator in katsim for mkat correlators.

Reviewer: @sratcliffe 
