### PR TITLE
Remove max_heaps setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install --no-deps \
     scikits.fitting==0.5.1 \
     manhole==1.0.0 \
     six==1.9.0 \
-    spead2==0.3.0 \
+    spead2==0.4.0 \
     git+ssh://git@github.com/ska-sa/katpoint \
     git+ssh://git@github.com/ska-sa/katsdpsigproc \
     git+ssh://git@github.com/ska-sa/katsdpdisp \

--- a/katsdpingest/ingest_threads.py
+++ b/katsdpingest/ingest_threads.py
@@ -93,7 +93,7 @@ class CAMIngest(threading.Thread):
                 self.logger.info("Subscribing to multicast address {0}".format(endpoint.host))
             elif endpoint.host != '':
                 self.logger.warning("Ignoring non-multicast address {0}".format(endpoint.host))
-        rx_md = spead2.recv.Stream(spead2.ThreadPool(), bug_compat=spead2.BUG_COMPAT_PYSPEAD_0_5_2, max_heaps=255)
+        rx_md = spead2.recv.Stream(spead2.ThreadPool(), bug_compat=spead2.BUG_COMPAT_PYSPEAD_0_5_2)
         rx_md.add_udp_reader(self.spead_endpoints[0].port)
         self.rx = rx_md
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 h5py
-spead2>=0.3.0
+spead2>=0.4.0
 iniparse
 blinker
 scikits.fitting


### PR DESCRIPTION
This should no longer be necessary with spead 0.4, provided that heaps
don't get too out-of-order.

@sratcliffe, can you test that theory next time you do an integration test?
