### PR TITLE
Register missing sensors for file version 3.1

### DIFF
--- a/katsdpingest/telescope_model.py
+++ b/katsdpingest/telescope_model.py
@@ -338,7 +338,9 @@ class AntennaPositioner(TelescopeComponent):
         self._critical_sensors = ['observer','activity','target','pos_actual_scan_elev','pos_request_scan_elev','pos_actual_scan_azim','pos_request_scan_azim']
         self._std_sensors = ['dig_noise_diode', 'rsc_rxl_serial_number',
                              'rsc_rxs_serial_number', 'rsc_rxu_serial_number',
-                             'rsc_rxx_serial_number', 'ap_indexer_position']
+                             'rsc_rxx_serial_number', 'ap_indexer_position',
+                             'ap_point_error_tiltmeter_enabled',
+                             'ap_tilt_corr_azim', 'ap_tilt_corr_elev']
         self._build()
 
 class CorrelatorBeamformer(TelescopeComponent):
@@ -353,6 +355,12 @@ class Enviro(TelescopeComponent):
     def __init__(self, *args, **kwargs):
         super(Enviro, self).__init__(*args, **kwargs)
         self._std_sensors = ['air_pressure','air_relative_humidity','air_temperature','wind_speed','wind_direction']
+        self._build()
+
+class Ancillary(TelescopeComponent):
+    def __init__(self, *args, **kwargs):
+        super(Enviro, self).__init__(*args, **kwargs)
+        self._std_sensors = ['siggen_ku_frequency']
         self._build()
 
 class Digitiser(TelescopeComponent):

--- a/katsdpingest/test/test_telescope_model.py
+++ b/katsdpingest/test/test_telescope_model.py
@@ -20,8 +20,9 @@ class TelescopeModelTestCases(unittest.TestCase):
         m062 = tm.AntennaPositioner(name='m062')
         cbf = tm.CorrelatorBeamformer(name='data_rts')
         env = tm.Enviro(name='anc_asc')
+        anc = tm.Ancillary(name='anc')
         obs = tm.Observation(name='obs')
-        self.components = [m063, m062, cbf, env, obs]
+        self.components = [m063, m062, cbf, env, anc, obs]
         self.model = tm.TelescopeModel()
 
     def _build_fake_model(self, model):

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -29,7 +29,7 @@ from katsdpingest.ingest_threads import CAMIngest, CBFIngest
 
  # import model components. In the future this may be done by the sdp_proxy and the 
  # complete model passed in.
-from katsdpingest.telescope_model import AntennaPositioner, CorrelatorBeamformer, Enviro, TelescopeModel, Observation
+from katsdpingest.telescope_model import AntennaPositioner, CorrelatorBeamformer, Enviro, Ancillary, TelescopeModel, Observation
 
 # import katconf
 
@@ -164,9 +164,10 @@ class IngestDeviceServer(DeviceServer):
         # for RTS we build a standard model. Normally this would be provided by the sdp_proxy
         cbf = CorrelatorBeamformer(name='data_rts')
         env = Enviro(name='anc_asc')
+        anc = Ancillary(name='anc')
         self.obs = Observation(name='obs')
         self.model = TelescopeModel()
-        self.model.add_components([cbf,env,self.obs])
+        self.model.add_components([cbf, env, anc, self.obs])
 
         for a in self.antennas.split(","):
             self.model.add_components([AntennaPositioner(name=a)])


### PR DESCRIPTION
This adds the tilt and Ku frequency sensors to the telescope model so that
they actually make it into the file. The latter required a new telescope
component for the ancillary proxy ('anc') since Enviro only exposes the
lower-level 'anc_asc' (which seemed like a good idea at the time).
