### PR TITLE
More cam2telstate updates

### DIFF
--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -289,7 +289,8 @@ class Client(object):
                     self._logger.debug('Updated %s to %s with timestamp %s',
                                        sensor.sp_name, value, timestamp)
                 except katsdptelstate.ImmutableKeyError as e:
-                    self._logger.error(e)
+                    self._logger.error('Failed to set %s to %s with timestamp %s',
+                                       sensor.sp_name, value, timestamp, exc_info=True)
             else:
                 self._logger.warn("Sensor {} received update '{}' but we didn't subscribe (ignored)"
                                    .format(name, value))


### PR DESCRIPTION
This adds
- A random handful of CBF sensors, to check that they are being received (possibly more to be added)
- Makes parameters non-positional, so that they can be populated via telstate
- Removes --antenna parameter, and gets receptor list from a CAM sensor instead
