### PR TITLE
Fix the check for whether the sensor value is valid

### DIFF
--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -279,9 +279,9 @@ class Client(object):
                 else:
                     self._pool_resources.set_result(resources)
         else:
-            if status == 'unknown':
-                self._logger.warn("Sensor {} received update '{}' with status 'unknown' (ignored)"
-                                  .format(name, value))
+            if status not in ['nominal', 'warn', 'error']:
+                self._logger.warn("Sensor {} received update '{}' with status '{}' (ignored)"
+                                  .format(name, value, status))
             elif name in self._sensors:
                 sensor = self._sensors[name]
                 try:


### PR DESCRIPTION
Previously we accepted any update with status != unknown, but according
to the katcp spec, there are a number of other statuses that mean the
sensor value isn't valid. Now just check for nominal/warn/error which
are the only cases where the value is valid.
