### PR TITLE
Use ticks_between_spectra SPEAD item

### DIFF
--- a/katsdpingest/bf_ingest_server.py
+++ b/katsdpingest/bf_ingest_server.py
@@ -66,10 +66,6 @@ class _CaptureSession(object):
         if args.interface is not None:
             config.interface_address = _get_interface_address(args.interface)
         config.ibv = args.ibv
-        if args.cbf_channels:
-            config.total_channels = args.cbf_channels
-        else:
-            _logger.info('Assuming %d PFB channels; if not, pass --cbf-channels', config.total_channels)
         if args.affinity:
             config.disk_affinity = args.affinity[0]
             config.network_affinity = args.affinity[1]
@@ -129,7 +125,6 @@ class CaptureServer(object):
         Command-line arguments. The following arguments are required. Refer to
         the script for documentation of these options.
 
-        - cbf_channels
         - cbf_spead
         - file_base
         - buffer

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -90,10 +90,8 @@ class _TimeAverage(object):
     def __init__(self, cbf_attr, int_time):
         self.ratio = max(1, int(round(int_time / cbf_attr['int_time'])))
         self.int_time = self.ratio * cbf_attr['int_time']
-        # Interval in ADC clock cycles
-        clocks = 2 * cbf_attr['n_chans'] * cbf_attr['n_accs'] * self.ratio
-        self.interval = int(round(clocks * cbf_attr['scale_factor_timestamp'] /
-                                  (2 * cbf_attr['bandwidth'])))
+        # Integration time in timestamp ticks
+        self.interval = self.ratio * cbf_attr['ticks_between_spectra'] * cbf_attr['n_accs']
         self._start_ts = None
         self._ts = []
 

--- a/katsdpingest/receiver.py
+++ b/katsdpingest/receiver.py
@@ -21,7 +21,8 @@ CBF_SPEAD_SENSORS = frozenset(["flags_xeng_raw"])
 # Attributes that are required for data to be correctly ingested
 CBF_CRITICAL_ATTRS = frozenset([
     'adc_sample_rate', 'n_chans', 'n_accs', 'n_bls', 'bls_ordering',
-    'bandwidth', 'center_freq', 'sync_time', 'int_time', 'scale_factor_timestamp'])
+    'bandwidth', 'center_freq',
+    'sync_time', 'int_time', 'scale_factor_timestamp', 'ticks_between_spectra'])
 
 
 def is_cbf_sensor(name):
@@ -205,10 +206,7 @@ class Receiver(object):
             return False
         # TODO: once CBF switches to new format, require 'frequency' too
         if self._interval is None:
-            self._interval = int(round(self.cbf_attr['n_chans'] *
-                                       self.cbf_attr['n_accs'] *
-                                       self.cbf_attr['scale_factor_timestamp'] /
-                                       self.cbf_attr['bandwidth']))
+            self._interval = self.cbf_attr['ticks_between_spectra'] * self.cbf_attr['n_accs']
 
         return True
 

--- a/katsdpingest/test/test_ingest_session.py
+++ b/katsdpingest/test/test_ingest_session.py
@@ -17,7 +17,8 @@ class TestTimeAverage(object):
             'bandwidth': 856000000,
             'n_accs': 123456,
             'n_chans': 4096,
-            'int_time': 0.75
+            'int_time': 0.75,
+            'ticks_between_spectra': 8192
         }
         self.input_interval = 123456 * 4096 * 2
 

--- a/katsdpingest/test/test_receiver.py
+++ b/katsdpingest/test/test_receiver.py
@@ -145,6 +145,8 @@ class TestReceiver(object):
                 (), format=[('u', 48)], value=14000000)
             ig.add_item(0x1046, 'scale_factor_timestamp', 'Timestamp scaling factor. Divide the SPEAD data packet timestamp by this number to get back to seconds since last sync.',
                 (), format=[('f', 64)], value=self.adc_sample_rate)
+            ig.add_item(0x104A, 'ticks_between_spectra', 'Number of sample ticks between spectra.',
+                (), format=[('u', 48)], value=2 * self.n_chans)
             ig.add_item(0x1600, 'timestamp', 'Timestamp of start of this integration. uint counting multiples of ADC samples since last sync (sync_time, id=0x1027). Divide this number by timestamp_scale (id=0x1046) to get back to seconds since last sync when this integration was actually started. Note that the receiver will need to figure out the centre timestamp of the accumulation (eg, by adding half of int_time, id 0x1016).',
                 (), None, format=[('u', 48)])
             ig.add_item(0x4103, 'frequency', 'Identifies the first channel in the band of frequencies in the SPEAD heap. Can be used to reconstruct the full spectrum.',

--- a/scripts/bf_ingest.py
+++ b/scripts/bf_ingest.py
@@ -36,7 +36,7 @@ def configure_logging(level):
 
 def main():
     parser = katsdptelstate.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--cbf-channels', type=int, help='total number of PFB channels [defaults to number of channels in stream]')
+    parser.add_argument('--cbf-channels', type=int, help='unused, kept for backwards compatibility')
     parser.add_argument('--cbf-spead', type=katsdptelstate.endpoint.endpoint_parser(7148), default=':7148', help='endpoints to listen for CBF SPEAD stream (including multicast IPs). [<ip>[+<count>]][:port].', metavar='ENDPOINTS')
     parser.add_argument('--log-level', '-l', type=str, metavar='LEVEL', default='INFO', help='log level')
     parser.add_argument('--file-base', default='.', type=str, help='base directory into which to write HDF5 files', metavar='DIR')
@@ -53,7 +53,8 @@ def main():
     if not os.access(args.file_base, os.W_OK):
         logging.error('Target directory (%s) is not writable', args.file_base)
         sys.exit(1)
-
+    if args.cbf_channels is not None:
+        logging.warn('Option --cbf-channels is unused and will be removed in future')
     ioloop = AsyncIOMainLoop()
     ioloop.install()
     server = KatcpCaptureServer(args, trollius.get_event_loop())


### PR DESCRIPTION
CBF have started providing this SPEAD item to indicate the timestamp
difference between consecutive spectra from the PFB. While this could be
calculated anyway (as 2 \* n_chans) for the wideband correlator product,
there was not enough information to compute it for narrowband products
or for the beamformer with passband.

This commit uses this item in both the correlator and beamformer
capture. The --cbf-channels command-line argument to the beamformer is
deprecated and ignored; it will only be removed once the master
controller no longer tries to pass it.
