### PR TITLE
Fix obscure race conditions 

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -951,6 +951,9 @@ class CBFIngest(object):
 
     @trollius.coroutine
     def stop(self):
+        """Shut down the session. It is safe to make reentrant calls: each
+        will wait for the shutdown to complete.
+        """
         if self._run_future:
             self.rx.stop()
             yield From(self._run_future)


### PR DESCRIPTION
This fixes two conditions:
1. If a connection issues ?capture-done (possibly followed by another ?capture-init) while a capture-done is in progress, the other ?capture-done will incorrectly try to redo the cleanup. This has been changed to detect the race and skip the cleanup the second time.
2. It is possible to issue a ?capture-init during the shutdown path, and the resulting session will not be closed properly. This is handled by detecting that shutdown is in progress and failing the capture-init.
