### PR TITLE
Bound size of the _frames_complete queue

### DIFF
--- a/katsdpingest/receiver.py
+++ b/katsdpingest/receiver.py
@@ -118,7 +118,7 @@ class Receiver(object):
         self.cbf_channels = cbf_channels
         self._streams = [None] * len(use_endpoints)
         self._frames = None
-        self._frames_complete = trollius.Queue(loop=loop)
+        self._frames_complete = trollius.Queue(maxsize=1, loop=loop)
         self._futures = []
         self._interval = None
         self._loop = loop


### PR DESCRIPTION
This prevents unbounded memory usage if the backend does not keep up
with the arrival of data. Instead, things will block, eventually causing
packets to be dropped if the backend can't keep up.