### PR TITLE
Remove duplication cross correlations

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -470,7 +470,7 @@ class CBFIngest(object):
         def keep(baseline):
             ant1 = baseline[0][:-1]
             ant2 = baseline[1][:-1]
-            # Eliminate baselines that have the a lower numbered antenna as the
+            # Eliminate baselines that have a lower-numbered antenna as the
             # second input as these are almost certainly duplicates. This is only 
             # a problem in single pol mode and could be removed in the future.
             if ant2 < ant1:


### PR DESCRIPTION
This is needed for single pol operation because the correlator ends up sending duplicates baselines for each ordered pair of antennas (e.g. m000h-m001h and m001h-m000h).

@ludwigschwardt and @bmerry to review to give thought to any dire downstream consequences of this...