### PR TITLE
Prevent crash when zero channels are selected in passband

### DIFF
--- a/katsdpingest/bf_ingest_session.cpp
+++ b/katsdpingest/bf_ingest_session.cpp
@@ -1261,7 +1261,7 @@ receiver::receiver(const session_config &config)
     spectra_per_heap(config.spectra_per_heap),
     channels_per_heap(config.channels_per_heap),
     worker(1, affinity_vector(config.network_affinity)),
-    stream(*this, config.channels / config.channels_per_heap * config.live_heaps_per_substream),
+    stream(*this, std::max(1, config.channels / config.channels_per_heap) * config.live_heaps_per_substream),
     ring(config.ring_slots),
     free_ring(window_size + config.ring_slots + 1)
 {


### PR DESCRIPTION
Having zero channels selected would cause the stream to be instantiated
with zero slots of incoming heaps, which would fall over when metadata
heaps arrived.