### PR TITLE
Simplify bf_ingest

### DIFF
--- a/scripts/bf_ingest.py
+++ b/scripts/bf_ingest.py
@@ -31,7 +31,6 @@ def main():
     parser = katsdpservices.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--cbf-spead', type=katsdptelstate.endpoint.endpoint_list_parser(7148), default=':7148', help='endpoints to listen for CBF SPEAD stream (including multicast IPs). [<ip>[+<count>]][:port].', metavar='ENDPOINTS')
-    parser.add_argument('--no-spead-metadata', dest='spead_metadata', default=True, action='store_false', help='Ignore metadata sent in SPEAD stream')
     parser.add_argument('--stream-name', type=str, metavar='NAME', help='Stream name for metadata in telstate')
     parser.add_argument('--log-level', '-l', type=str, metavar='LEVEL', default=None, help='log level')
     parser.add_argument('--file-base', default='.', type=str, help='base directory into which to write HDF5 files', metavar='DIR')
@@ -44,6 +43,10 @@ def main():
     args = parser.parse_args()
     if args.affinity and len(args.affinity) < 2:
         parser.error('At least 2 CPUs must be specified for --affinity')
+    if args.telstate is None:
+        parser.error('--telstate is required')
+    if args.stream_name is None:
+        parser.error('--stream-name is required')
     if args.log_level is not None:
         logging.root.setLevel(args.log_level.upper())
     if not os.access(args.file_base, os.W_OK):


### PR DESCRIPTION
- Removes support for metadata via SPEAD entirely. The item IDs are also
  hard-coded, so the descriptors are completely ignored.
- Assumes telescope state is already populated on startup, and does not
  wait for sdp_cam2telstate_ready. This removes the whole METADATA state
  from the state machine, and also allows missing sensors to be detected
  early (on startup), similar to correlation products ingest.