### PR TITLE
Fix a few serious issues with how CAM flags were being applied

### DIFF
--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -557,7 +557,7 @@ class Accum(accel.Operation):
         Input weights
     **flags_in** : baselines × channels, uint8
         Input flags: non-zero values cause downweighting by 2^-64
-    **channel_flags** : full-channels, uint8
+    **channel_flags** : channels, uint8
         Predetermined flags per channel
     **baseline_flags** : baselines, uint8
         Predetermined flags per baseline
@@ -1087,7 +1087,7 @@ class IngestOperation(accel.OperationSequence):
 
     **vis_in** : channels × baselines × 2, int32
         Input visibilities from the correlator
-    **channel_flags** : kept-channels, uint8
+    **channel_flags** : channels, uint8
         Predefined per-channel flags
     **baseline_flags** : baselines, uint8
         Predefined per-baseline flags, in the post-permutation ordering


### PR DESCRIPTION
- The computed CAM flags were being put into temporary buffers and then
  thrown away, and the data transferred to the GPU was being taken from
  uninitialised memory. This is conceivably the cause of MKAIV-707,
  although it remains to be proven.
- Data missing for the guard regions (values used only for RFI
  backgrounding) was not flagged as sound, and would have affected the
  background.
- The x_channel_flags telstate key was not being sliced to the relevant
  subset of channels.
- Some of the documentation about the indexing of channel_flags was out
  of date.

The unit test has also been been improved to catch these bugs.