### PR TITLE
Use CAM sky centre frequency

### DIFF
--- a/katsdpingest/ingest_server.py
+++ b/katsdpingest/ingest_server.py
@@ -37,7 +37,7 @@ class IngestDeviceServer(AsyncDeviceServer):
         Passed to :class:`katcp.DeviceServer`
     """
 
-    VERSION_INFO = ("sdp-ingest", 0, 1)
+    VERSION_INFO = ("sdp-ingest", 0, 2)
     BUILD_INFO = ('katsdpingest',) + tuple(katsdpingest.__version__.split('.', 1)) + ('',)
 
     def __init__(self, user_args, channel_ranges, cbf_attr, context, *args, **kwargs):
@@ -166,20 +166,6 @@ class IngestDeviceServer(AsyncDeviceServer):
         smsg = "Capture initialised at %s" % time.ctime()
         logger.info(smsg)
         raise tornado.gen.Return(("ok", smsg))
-
-    @request(Float())
-    @return_reply(Str())
-    def request_set_center_freq(self, req, center_freq_hz):
-        """Set the center freq for use in the signal displays.
-
-        Parameters
-        ----------
-        center_freq_hz : int
-            The current system center frequency in hz
-        """
-        self.cbf_ingest.set_center_freq(center_freq_hz)
-        logger.info("Center frequency set to %f Hz", center_freq_hz)
-        return ("ok", "set")
 
     @request(Str())
     @return_reply(Str())

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -649,7 +649,7 @@ class CBFIngest(object):
             dtype=np.uint8, shape=(n_spec_channels, n_perc_signals))
         self.ig_sd.add_item(
             name="center_freq", id=0x1011,
-            description="The center frequency of the DBE in Hz, 64-bit IEEE floating-point number.",
+            description="The center frequency of the signal display data in Hz, 64-bit IEEE floating-point number.",
             shape=(), dtype=None, format=[('f', 64)])
         self.ig_sd.add_item(
             name=('sd_timestamp'), id=0x3502,
@@ -678,7 +678,6 @@ class CBFIngest(object):
 
     def __init__(self, args, cbf_attr, channel_ranges, context, my_sensors, telstate):
         self._sdisp_ips = {}
-        self._center_freq = None
         self._run_future = None
         # Set by stop to abort prior to creating the receiver
         self._stopped = True
@@ -779,10 +778,6 @@ class CBFIngest(object):
         stream.set_cnt_sequence(self.channel_ranges.sd_output.start,
                                 len(self.channel_ranges.cbf))
         self._sdisp_ips[endpoint.host] = stream
-
-    def set_center_freq(self, center_freq):
-        """Change the center frequency reported to signal displays."""
-        self._center_freq = center_freq
 
     def _flush_output(self, timestamps):
         """Finalise averaging of a group of input dumps and emit an output dump"""
@@ -966,9 +961,7 @@ class CBFIngest(object):
             self.ig_sd['sd_percspectrumflags'].value = np.vstack(percentiles_flags).transpose()
             # Translate CBF-width center_freq to the center_freq for the
             # signal display product.
-            cbf_center_freq = self._center_freq
-            if cbf_center_freq is None:
-                cbf_center_freq = self.cbf_attr.get('center_freq')
+            cbf_center_freq = self.cbf_attr.get('center_freq')
             if cbf_center_freq is not None:
                 channel_width = self.cbf_attr['bandwidth'] / len(self.channel_ranges.cbf)
                 cbf_mid = (self.channel_ranges.cbf.start + self.channel_ranges.cbf.stop) / 2

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -440,25 +440,6 @@ class TestIngestDeviceServer(object):
 
     @async_test
     @tornado.gen.coroutine
-    def test_set_center_freq(self):
-        """A center frequency set by ?set-center-freq is reflected in signal display output."""
-        cbf_center_freq = 2e9
-        channel_width = self.cbf_attr['bandwidth'] / self.cbf_attr['n_chans']
-        sd_output_channels = self.user_args.sd_output_channels
-        sd_center_channel = (sd_output_channels.start + sd_output_channels.stop) / 2
-        sd_center_freq = (cbf_center_freq
-                          + (sd_center_channel - self.cbf_attr['n_chans'] / 2) * channel_width)
-        yield self.make_request('set-center-freq', cbf_center_freq)
-        yield self.make_request('capture-init')
-        yield self.make_request('capture-done')
-
-        sd_tx = self._sd_tx[('127.0.0.2', 7149)]
-        call = sd_tx.async_send_heap.mock_calls[1]
-        ig = decode_heap_ig(call[1][0])
-        assert_equal(sd_center_freq, ig['center_freq'].value)
-
-    @async_test
-    @tornado.gen.coroutine
     def test_add_sdisp_ip(self):
         """Add additional addresses with add-sdisp-ip."""
         yield self.make_request('add-sdisp-ip', '127.0.0.3:8000')

--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -157,7 +157,8 @@ SENSORS = [
     Sensor('{stream_fengine}_n_samples_between_spectra',
            sp_name='{stream_fengine}_ticks_between_spectra', immutable=True),
     Sensor('{stream_fengine}_n_chans', immutable=True),
-    Sensor('{stream_fengine}_center_freq', immutable=True),
+    Sensor('{subarray}_streams_{stream_base_fengine}_centre_frequency',
+           sp_name='{stream_base_fengine}_center_freq', immutable=True),
     # TODO: need to figure out how to deal with multi-stage FFT instruments
     Sensor('{stream_fengine}_{inputn}_fft0_shift',
            sp_name='{stream_fengine}_fft_shift'),


### PR DESCRIPTION
- In cam2telstate, use the CAM-provided sensor that indicates the sky
  centre-frequency, renaming it to replace the CBF center-freq sensor
  (and yes, apparently we can't agree on how to spell "centre").
- Remove the set-center-freq katcp command from ingest, which as far as
  I know was never used.