### PR TITLE
Change output timestamps from centroid to mid-group

### DIFF
--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -315,8 +315,6 @@ class TestIngestDeviceServer(object):
         The timestamps are in seconds since the sync time. The full CBF channel
         range is returned.
         """
-        timestamps = (self._timestamps / self.cbf_attr['scale_factor_timestamp']
-                      + 0.5 * self.cbf_attr['int_time'])
         # Convert to complex64 from pairs of real and imag int
         vis = (self._data[..., 0] + self._data[..., 1] * 1j).astype(np.complex64)
         # Scaling
@@ -326,9 +324,9 @@ class TestIngestDeviceServer(object):
         batch_edges = np.arange(0, vis.shape[0], time_ratio)
         batch_sizes = np.minimum(batch_edges + time_ratio, vis.shape[0]) - batch_edges
         vis = np.add.reduceat(vis, batch_edges, axis=0)
-        timestamps = np.add.reduceat(timestamps, batch_edges, axis=0)
         vis /= batch_sizes[:, np.newaxis, np.newaxis]
-        timestamps /= batch_sizes
+        timestamps = self._timestamps[::time_ratio] / self.cbf_attr['scale_factor_timestamp'] \
+                + 0.5 * self._telstate['sdp_l0_int_time']
         # Baseline permutation
         bls = BaselineOrdering(self.cbf_attr['bls_ordering'], self.user_args.antenna_mask)
         inv_permutation = np.empty(len(bls.sdp_bls_ordering), np.int)

--- a/katsdpingest/test/test_ingest_session.py
+++ b/katsdpingest/test/test_ingest_session.py
@@ -48,7 +48,6 @@ class TestTimeAverage(object):
         assert_equal(3, avg.ratio)
         assert_equal(avg.ratio * self.input_interval, avg.interval)
         assert_is(None, avg._start_ts)
-        assert_equal([], avg._ts)
 
     def make_ts(self, idx):
         if isinstance(idx, list):
@@ -65,21 +64,18 @@ class TestTimeAverage(object):
         assert not avg.flush.called
 
         avg.add_timestamp(self.make_ts(4))  # Skip first packet in the group
-        avg.flush.assert_called_once_with(self.make_ts([0, 2, 1]))
+        avg.flush.assert_called_once_with(self.make_ts(1.5))
         avg.flush.reset_mock()
         assert_equal(self.make_ts(3), avg._start_ts)
-        assert_equal([self.make_ts(4)], avg._ts)
 
         avg.add_timestamp(self.make_ts(12))  # Skip some whole groups
-        avg.flush.assert_called_once_with(self.make_ts([4]))
+        avg.flush.assert_called_once_with(self.make_ts(4.5))
         avg.flush.reset_mock()
         assert_equal(self.make_ts(12), avg._start_ts)
-        assert_equal([self.make_ts(12)], avg._ts)
 
         avg.finish()
-        avg.flush.assert_called_once_with(self.make_ts([12]))
+        avg.flush.assert_called_once_with(self.make_ts(13.5))
         assert_is(None, avg._start_ts)
-        assert_equal([], avg._ts)
 
     def test_alignment(self):
         """Phase must be independent of first timestamp seen"""


### PR DESCRIPTION
This matters only if some members of the group were missing -
particularly at the start and end, but potentially also when heaps are
dropped.

This change ensures that multiple ingest servers will have aligned
timestamps, even if one of them drops some data that another does not.