### PR TITLE
Avoid a TypeError when trying to stop _device_server

### DIFF
--- a/scripts/cam2telstate.py
+++ b/scripts/cam2telstate.py
@@ -404,7 +404,8 @@ class Client(object):
                 self._logger.debug('Set signal handler for %s', signal_number)
         except Exception:
             self._logger.error("Exception during startup", exc_info=True)
-            yield self._device_server.stop(timeout=None)
+            if self._device_server is not None:
+                yield self._device_server.stop(timeout=None)
             self._loop.stop()
         else:
             self._logger.info("Startup complete")


### PR DESCRIPTION
I happened to notice this cascading failure happening on site, where an
exception occurs early in startup, the exception handler tries to stop
the device server, but it is has not yet been initialised to that throws
another exception.