### PR TITLE
Fix memory corruption

### DIFF
--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -1302,7 +1302,7 @@ class IngestOperation(accel.OperationSequence):
             compounds[name + '_flags'] = [name + '_flags:dest', name + '_flags:data']
 
         aliases = {
-            'scratch1': ['vis_in', 'auto_weights', 'vis_mid',
+            'scratch1': ['auto_weights', 'vis_mid',
                          'flagger:deviations_t', 'flagger:flags',
                          'cont_weights_fp32', 'sd_cont_weights_fp32']
         }


### PR DESCRIPTION
The `vis_in` buffer was being aliased to other buffers that were
supposedly not used at the same time. However, the `_frame_job` and
`_flush_output_job` were concurrent, and in some cases the upload to
vis_in in `_frame_job` would get clobbered by the computations using
`[sd_]cont_weights_fp32` in the flush jobs.

Fixes SR-955.