### PR TITLE
ECP-64 test receiver script

### DIFF
--- a/scripts/ecp64.py
+++ b/scripts/ecp64.py
@@ -133,7 +133,6 @@ if __name__ == '__main__':
 
     raw_data = OrderedDict()
     for heap in rx:
-        # print heap
         new_items = ig.update(heap)
         if 'timestamp' not in new_items:
             continue


### PR DESCRIPTION
This captures the ECP-64 digitiser spectrometer stream to a NumPy
data file. The script was used in the original lab tests in November
2016 and serves as a starting point for a proper receiver.