### PR TITLE
Allow capture-init to take program block ID

### DIFF
--- a/katsdpingest/bf_ingest_server.py
+++ b/katsdpingest/bf_ingest_server.py
@@ -17,7 +17,7 @@ from trollius import From, Return
 import tornado
 
 import katcp
-from katcp.kattypes import request, return_reply
+from katcp.kattypes import request, return_reply, Str
 
 from katsdpfilewriter import telescope_model, ar1_model, file_writer
 import katsdpservices
@@ -287,10 +287,10 @@ class KatcpCaptureServer(CaptureServer, katcp.DeviceServer):
         start_future = trollius.async(self.start_capture(), loop=self._loop)
         yield katsdpservices.asyncio.to_tornado_future(start_future)
 
-    @request()
+    @request(Str(optional=True))
     @return_reply()
     @tornado.gen.coroutine
-    def request_capture_init(self, sock):
+    def request_capture_init(self, sock, program_block_id=None):
         """Start capture to file."""
         if self.capturing:
             raise tornado.gen.Return(('fail', 'already capturing'))

--- a/katsdpingest/ingest_server.py
+++ b/katsdpingest/ingest_server.py
@@ -148,9 +148,10 @@ class IngestDeviceServer(AsyncDeviceServer):
                 return ("fail", "Unknown log level specified {}".format(level))
             return ("ok", "Log level set to {}".format(level))
 
+    @request(Str(optional=True))
     @return_reply(Str())
     @tornado.gen.coroutine
-    def request_capture_init(self, req, msg):
+    def request_capture_init(self, req, program_block_id=None):
         """Spawns ingest session to capture suitable data to produce
         the L0 output stream."""
         if self.cbf_ingest.capturing:


### PR DESCRIPTION
At the moment it is dropped on the floor, but in future would use
telstate namespace feature. At the moment it is optional until
katsdpcontroller is updated to match.