### PR TITLE
Increase bf_ingest window size

### DIFF
--- a/katsdpingest/bf_ingest_session.cpp
+++ b/katsdpingest/bf_ingest_session.cpp
@@ -694,7 +694,7 @@ private:
     bool use_ibv = false;
 
     /// Depth of window
-    static constexpr std::size_t window_size = 2;
+    static constexpr std::size_t window_size = 64;
 
     // Metadata copied from or computed from the session_config
     const std::int64_t ticks_between_spectra;


### PR DESCRIPTION
This controls the acceptable variation between arrival times of heaps
with the same timestamp. The previous value was working for ROACH but
broke down on SKARAB when the start of heap N+2 arrived from one engine
before the end of heap N from another.

This needs some testing to make sure the performance is acceptable,
since that buffer no longer fits in L3 cache.