### PR TITLE
Disable poll-mode SPEAD reception

### DIFF
--- a/katsdpingest/receiver.py
+++ b/katsdpingest/receiver.py
@@ -193,12 +193,8 @@ class Receiver(object):
             if ifaddr is None:
                 raise ValueError('Cannot use ibverbs without an interface address')
             endpoint_tuples = [(endpoint.host, endpoint.port) for endpoint in endpoints]
-            # We use poll mode (comp_vector=-1) rather than interrupt-driven receiving,
-            # because the latter has performance anomalies when running several
-            # processes on the same host which lead to packet losses.
             stream.add_udp_ibv_reader(endpoint_tuples, ifaddr,
-                                      max_size=max_packet_size, buffer_size=buffer_size,
-                                      comp_vector=-1)
+                                      max_size=max_packet_size, buffer_size=buffer_size)
         else:
             for endpoint in endpoints:
                 if ifaddr is None:


### PR DESCRIPTION
The anomaly that it worked around seems to have been a machine which was
not configured properly to disable low-power C states.