### PR TITLE
Upgrade digitiser capture to spead2 1.7.0

### DIFF
--- a/digitiser_capture/Dockerfile
+++ b/digitiser_capture/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install netifaces==0.10.4
 # Check out and build spead2
 RUN mkdir -p /tmp/install/digitiser_decode && \
     cd /tmp/install && \
-    git clone --single-branch --branch v1.6.0 --depth 1 https://github.com/ska-sa/spead2 && \
+    git clone --single-branch --branch v1.7.0 --depth 1 https://github.com/ska-sa/spead2 && \
     mkdir spead2/build && \
     cd spead2 && ./bootstrap.sh --no-python && \
     cd build && \

--- a/digitiser_capture/Makefile
+++ b/digitiser_capture/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 CXXFLAGS = -std=c++11 -Wall -g -pthread $(shell pkg-config --cflags spead2) -O3
-LDFLAGS = -L$(SPEAD2_DIR)/src $(shell pkg-config --libs --static spead2) -lpcap -lboost_program_options -lboost_system -pthread -ltbb
+LDFLAGS = -L$(SPEAD2_DIR)/src $(shell pkg-config --libs --static spead2) -lboost_program_options -lboost_system -pthread -ltbb
 
 all: digitiser_decode
 


### PR DESCRIPTION
This allows the internal pcap file reader to be ditched in favour of the
version added to spead2 1.7.0 (which was based on this one but has some
improvements). It also fixes the spew of warning messages when the
decoder doesn't run as fast as the file reader.