### PR TITLE
Updates to first_timestamp telstate entry

### DIFF
--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -51,8 +51,8 @@ class MockReceiver(object):
                  endpoints, interface_address, ibv,
                  max_streams, max_packet_size, buffer_size,
                  channel_range, cbf_channels, sensors,
-                 cbf_attr, active_frames=2, loop=None, telstate=None,
-                 pauses=None):
+                 cbf_attr, active_frames=2, loop=None, telstates=None,
+                 l0_int_time=None, pauses=None):
         assert data.shape[0] == len(timestamps)
         self._next_frame = 0
         self._data = data

--- a/katsdpingest/test/test_ingest_session.py
+++ b/katsdpingest/test/test_ingest_session.py
@@ -136,18 +136,25 @@ class TestTelstateReceiver(object):
         # We don't want to bother setting up a valid Receiver base class, we
         # just want to test the subclass, so we mock in a different base.
         class DummyBase(object):
-            pass
+            def __init__(self, cbf_attr):
+                self.cbf_attr = cbf_attr
 
         patcher = mock.patch.object(ingest_session.TelstateReceiver, '__bases__', (DummyBase,))
         with patcher:
             patcher.is_local = True   # otherwise mock tries to delete __bases__
-            receiver = ingest_session.TelstateReceiver(telstate=self.telstate)
+            cbf_attr = {'scale_factor_timestamp': 4.0}
+            receiver = ingest_session.TelstateReceiver(cbf_attr=cbf_attr,
+                                                       telstates=[self.telstate],
+                                                       l0_int_time=3.0)
             # Set first value
             assert_equal(12345, receiver._first_timestamp(12345))
             # Try a different value, first value must stick
             assert_equal(12345, receiver._first_timestamp(54321))
             # Set same value
             assert_equal(12345, receiver._first_timestamp(12345))
+            # Check the telstate keys
+            assert_equal(12345, self.telstate['first_timestamp_adc'])
+            assert_equal(3087.75, self.telstate['first_timestamp'])
 
 
 class TestCBFIngest(object):


### PR DESCRIPTION
- It is now placed in the L0 stream namespace (for each L0 stream
  produced by the ingest), instead of the baseline-correlation-products
  namespace. This isn't strictly necessary, but is a better logical fit
  given the next change.
- The raw ADC count now goes into first_timestamp_adc, and
  first_timestamp contains the timestamp (relative to the sync time)
  that would go into dump index 0.

The (absolute) timestamp of the dump with index i can now be synthesized
as ts['sync_time'] + ts['first_timestamp'] + i*ts['int_time'], given a
telstate view that includes both per-CB-per-stream and per-stream
prefixes.

Closes SR-1050