### PR TITLE
Count non-data heaps

### DIFF
--- a/katsdpingest/katsdpingest/receiver.py
+++ b/katsdpingest/katsdpingest/receiver.py
@@ -26,7 +26,7 @@ REJECT_HEAP_TYPES = {
     'too-old': 'timestamp is prior to the start time',
     'bad-channel': 'channel offset is not aligned to the substreams',
     'missing': 'expected heap was not received',
-    'non-data': 'heap without payload e.g. descriptor or start-of-stream'
+    'metadata': 'heap without payload e.g. descriptor or start-of-stream'
 }
 
 
@@ -309,7 +309,7 @@ class Receiver(object):
                 except spead2.Stopped:
                     break
                 if heap.is_end_of_stream():
-                    self._reject_heaps['non-data'].value += 1
+                    self._reject_heaps['metadata'].value += 1
                     n_stop += 1
                     _logger.debug("%d/%d endpoints stopped on stream %d",
                                   n_stop, n_endpoints, stream_idx)
@@ -339,7 +339,7 @@ class Receiver(object):
                     self._descriptors_received.value = True
                 if 'xeng_raw' not in updated:
                     _logger.debug("CBF non-data heap received on stream %d", stream_idx)
-                    self._reject_heaps['non-data'].value += 1
+                    self._reject_heaps['metadata'].value += 1
                     continue
                 if 'timestamp' not in updated:
                     _logger.warning("CBF heap without timestamp received on stream %d", stream_idx)


### PR DESCRIPTION
This adds a new sensor to count the number of heaps that are complete
but don't have an xeng_raw - which will normally be descriptors plus
start/end-of-stream heaps.