### PR TITLE
Be more robust to invalid sdisp_timeseries_mask

### DIFF
--- a/katsdpingest/katsdpingest/ingest_session.py
+++ b/katsdpingest/katsdpingest/ingest_session.py
@@ -999,6 +999,7 @@ class CBFIngest(object):
     def _flush_sd(self, output_idx):
         """Finalise averaging of a group of dumps for signal display, and send
         signal display data to the signal display server"""
+        all_channels = len(self.channel_ranges.all_sd_output)
         custom_signals_indices = None
         full_mask = None
         try:
@@ -1011,14 +1012,13 @@ class CBFIngest(object):
             full_mask = np.array(
                 self.telstate_sdisp['sdisp_timeseries_mask'],
                 dtype=np.float32, copy=False)
-        except KeyError:
+        except (KeyError, ValueError, TypeError):
             pass
 
         if custom_signals_indices is None:
             custom_signals_indices = np.array([], dtype=np.uint32)
-        if full_mask is None:
-            n_channels = len(self.channel_ranges.all_sd_output)
-            full_mask = np.ones(n_channels, np.float32) / n_channels
+        if full_mask is None or full_mask.shape != (all_channels,):
+            full_mask = np.ones(all_channels, np.float32) / all_channels
         # Create mask from full_mask. mask contains a weight for each channel
         # in computed, but those outside of sd_output are zero.
         mask = np.zeros(len(self.channel_ranges.computed), np.float32)


### PR DESCRIPTION
If the timeseries mask had the wrong shape, it could trigger a numpy
error and terminate the capture thread. Now we explicitly check the
shape, and ignore timeseries_mask if it is bad.