### PR TITLE
Rework autotuning

### DIFF
--- a/katsdpingest/scripts/autotune_mkimage.py
+++ b/katsdpingest/scripts/autotune_mkimage.py
@@ -5,41 +5,80 @@ autotuning results.
 
 from __future__ import print_function
 import argparse
-import glob
-import datetime
 import sys
 import os
 import os.path
-import subprocess
+import tempfile
+import shutil
+import tarfile
+import io
+import contextlib
+from textwrap import dedent
+
 import docker
 from docker import APIClient
 
 
-def get_existing(cli, image):
-    container = cli.create_container(image=image)
-    container_id = container['Id']
+DOCKERFILE = dedent('''\
+    FROM {base}
+    COPY --chown=kat:kat tuning.db /home/kat/.cache/katsdpsigproc/
+''')
+
+
+def get_cache(cli, container_id):
+    data, _ = cli.get_archive(container_id, '/home/kat/.cache/katsdpsigproc/tuning.db')
+    tardata = b''.join(data)
+    with tarfile.open(fileobj=io.BytesIO(tardata)) as tar:
+        with contextlib.closing(tar.extractfile('tuning.db')) as f:
+            return f.read()
+
+
+def tune(cli, base_image, skip):
+    """Run a throwaway container to do the autotuning, and extract the result."""
+    command = ['ingest_autotune.py'] if not skip else ['/bin/true']
+    # If we're running inside a Docker container, expose the same devices
+    # to our child container.
+    environment = {
+        'NVIDIA_VISIBLE_DEVICES': os.environ.get('NVIDIA_VISIBLE_DEVICES', 'all')
+    }
+    container = cli.create_container(
+        image=base_image,
+        command=command,
+        environment=environment,
+        runtime='nvidia')
     try:
         if container['Warnings']:
             print(container['Warnings'], file=sys.stderr)
-        data, _ = cli.get_archive(container['Id'], '/home/kat/.cache/katsdpsigproc')
-        b''.join(data)
+        container_id = container['Id']
+        cli.start(container_id)
+        try:
+            for line in cli.logs(container_id, True, True, True):
+                sys.stdout.write(line)
+            result = cli.wait(container_id)
+        except (Exception, KeyboardInterrupt):
+            cli.stop(container_id, timeout=2)
+            raise
+        if result['StatusCode'] == 0:
+            return get_cache(cli, container_id)
+        else:
+            msg = 'Autotuning failed with status {0[Error]} ({0[StatusCode]})'.format(result)
+            raise RuntimeError(msg)
     finally:
         cli.remove_container(container_id)
 
 
-def split_tag(path):
-    """Split an image or image:tag string into image and tag parts. Docker
-    doesn't seem to have a spec for this, so we assume that anything after the
-    last colon is a tag, *unless* it contains a slash. The exception is so that
-    a port number on a registry isn't mistaken for a tag.
-    """
-    last_slash = path.rfind('/')
-    last_colon = path.rfind(':')
-    if last_colon > last_slash:
-        return path[:last_colon], path[last_colon + 1:]
-    else:
-        # No tag
-        return path, ''
+def build(cli, image, base_image, tuning):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
+            f.write(DOCKERFILE.format(base=base_image))
+        with open(os.path.join(tmpdir, 'tuning.db'), 'wb') as f:
+            f.write(tuning)
+        for line in cli.build(path=tmpdir, rm=True, tag=image, decode=True):
+            if 'stream' in line:
+                sys.stdout.write(line['stream'])
+    finally:
+        shutil.rmtree(tmpdir)
 
 
 def main():
@@ -62,11 +101,10 @@ def main():
         '--tls', action='store_true',
         help='Use TLS to connect to Docker daemon')
     args = parser.parse_args()
+    if args.skip and not args.copy and args.copy_from is None:
+        parser.error('Cannot use --skip without --copy or --copy-from')
 
     if args.tls:
-        # docker-py doesn't support using tcp:// in the URL
-        if args.host.startswith('tcp://'):
-            args.host = 'https://' + args.host[6:]
         tls_config = docker.tls.TLSConfig(
             client_cert=(os.path.expanduser('~/.docker/cert.pem'),
                          os.path.expanduser('~/.docker/key.pem')),
@@ -74,54 +112,16 @@ def main():
         cli = APIClient(args.host, tls=tls_config)
     else:
         cli = APIClient(args.host)
-    old = None
-    if args.copy or args.copy_from is not None:
-        if args.copy_from is None:
-            args.copy_from = args.image
-        old = get_existing(cli, args.copy_from)
 
-    # put_archive makes the cache owned by root. To deal with this, we run as
-    # root, then fix up permissions afterwards.
-    command = ['sh', '-c', 'HOME=/home/kat ingest_autotune.py && chown -R kat:kat /home/kat/.cache']
-    # If we're running inside a Docker container, expose the same devices
-    # to our child container.
-    environment = ['NVIDIA_VISIBLE_DEVICES=' + os.environ.get('NVIDIA_VISIBLE_DEVICES', 'all')]
-    container = cli.create_container(
-        image=args.base_image,
-        command=command,
-        environment=environment,
-        user='root',
-        runtime='nvidia')
-    try:
-        if container['Warnings']:
-            print(container['Warnings'], file=sys.stderr)
-        container_id = container['Id']
-        if old is not None:
-            cli.put_archive(container_id, '/home/kat/.cache', old)
-        if not args.skip:
-            cli.start(container_id)
-            try:
-                for line in cli.logs(container_id, True, True, True):
-                    sys.stdout.write(line)
-                result = cli.wait(container_id)
-            except (Exception, KeyboardInterrupt):
-                cli.stop(container_id, timeout=2)
-                raise
-        else:
-            result = {u'StatusCode': 0, u'Error': None}
-        if result['StatusCode'] == 0:
-            msg = 'Autotuning run at {}'.format(datetime.datetime.now().isoformat())
-            image, tag = split_tag(args.image)
-            # Passing 'USER kat' sets the user back to kat, since we
-            # override it to root earlier.
-            cli.commit(container_id, image, tag, msg, changes='USER kat')
-            print('Committed to', args.image)
-            return 0
-        else:
-            print('Autotuning failed with status {0[Error]} ({0[StatusCode]})', result)
-            return 1
-    finally:
-        cli.remove_container(container_id)
+    if args.copy_from is not None:
+        tune_base = args.copy_from
+    elif args.copy:
+        tune_base = args.image
+    else:
+        tune_base = args.base_image
+
+    tuned = tune(cli, tune_base, args.skip)
+    build(cli, args.image, args.base_image, tuned)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes SR-1215, as well as another typo that broke --copy.

The old design used put_archive to optionally inject an existing tuning
database into a container, then ran autotuning. That required some hacky
workarounds because put_archive makes everything root-owned.

The new approach first does tuning using a throw-away container and
extracts the resulting tuning database. It then constructs a Dockerfile
on the fly to build the new image and inject the tuning database. This
ensures that no unwanted files get sucked along (e.g. see SR-1215).