### PR TITLE
Provide sensors to track amount of flagging

### DIFF
--- a/katsdpingest/katsdpingest/ingest_kernels/count_flags.mako
+++ b/katsdpingest/katsdpingest/ingest_kernels/count_flags.mako
@@ -7,7 +7,10 @@ ${wg_reduce.define_function('unsigned int', wgs, 'reduce', 'scratch_t', wg_reduc
 #define WGS ${wgs}
 #define BITS 8
 
-/* This implementation is far from optimal, but it's also not massively
+/**
+ * Count number of visibilities with each flag bit, per baseline.
+ *
+ * This implementation is far from optimal, but it's also not massively
  * performance-critical. Some ideas for future optimisation if necessary:
  *
  * - Have each workitem load 32 bits at a time instead of 8 (has some
@@ -19,9 +22,21 @@ ${wg_reduce.define_function('unsigned int', wgs, 'reduce', 'scratch_t', wg_reduc
  *   CPU-side reduction (more parallelism).
  * - Do the reduction on all the counts jointly, instead of one at a time.
  * - Handle baseline_flags right at the end, instead of inside the loop.
+ *
+ * @param[out] counts         Output counts, shape (baselines, 8), contiguous
+ * @param[out] any_counts     Count of visibilities with any flag, per baseline
+ * @param      flags          Per-visibility input flags, shape (baselines, flags_stride)
+ * @param      channel_flags  Per-channel flags to be combined into flags for counting
+ * @param      baseline_flags Per-baseline flags to be combined into flags for counting
+ * @param      flags_stride   Stride for @a flags
+ * @param      channels       Number of channels over which to do count
+ * @param      channel_start  Offset to first channel to count in @a flags and @a channel_flags
+ * @param      mask           Mask ANDed with the flags before counting (used to eliminate the
+ *                            pseudo-flag used to mark unflagged data).
  */
 KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void count_flags(
     GLOBAL unsigned int * RESTRICT counts,
+    GLOBAL unsigned int * RESTRICT any_counts,
     const GLOBAL unsigned char * RESTRICT flags,
     const GLOBAL unsigned char * RESTRICT channel_flags,
     const GLOBAL unsigned char * RESTRICT baseline_flags,
@@ -39,9 +54,11 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void count_flags(
     flags += baseline * flags_stride + channel_start;
     channel_flags += channel_start;
     unsigned int sums[BITS] = {};
+    unsigned int any = 0;
     for (int i = lid; i < channels; i += WGS)
     {
-        unsigned char flag = flags[i] | channel_flags[i] | baseline_flag;
+        unsigned char flag = (flags[i] | channel_flags[i] | baseline_flag) & mask;
+        any += (flag != 0);
         for (int j = 0; j < 8; j++)
         {
             sums[j] += (flag & 1);
@@ -49,14 +66,10 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void count_flags(
         }
     }
 
-    // Accumulate across workitems, and apply the mask
+    // Accumulate across workitems
     for (int i = 0; i < BITS; i++)
-    {
-        if (mask & (1 << i))
-            sums[i] = reduce(sums[i], lid, &scratch);
-        else
-            sums[i] = 0;
-    }
+        sums[i] = reduce(sums[i], lid, &scratch);
+    any = reduce(any, lid, &scratch);
 
     // Write results
     if (lid == 0)
@@ -64,5 +77,6 @@ KERNEL REQD_WORK_GROUP_SIZE(WGS, 1, 1) void count_flags(
         counts += baseline * BITS;
         for (int i = 0; i < BITS; i++)
             counts[i] += sums[i];
+        any_counts[baseline] += any;
     }
 }

--- a/katsdpingest/katsdpingest/ingest_server.py
+++ b/katsdpingest/katsdpingest/ingest_server.py
@@ -93,6 +93,14 @@ class IngestDeviceServer(AsyncDeviceServer):
                    "Number of payload dumps sent on L0 in this session "
                    " (prometheus: counter)",
                    initial_status=Sensor.NOMINAL),
+            Sensor(Sensor.INTEGER, "output-vis-total",
+                   "Number of spectral visibilities computed for signal displays in this session "
+                   " (prometheus: counter)",
+                   initial_status=Sensor.NOMINAL),
+            Sensor(Sensor.INTEGER, "output-flagged-total",
+                   "Number of flagged visibilities (out of output-vis-total) "
+                   " (prometheus: counter)",
+                   initial_status=Sensor.NOMINAL),
             Sensor(Sensor.BOOLEAN, "descriptors-received",
                    "Whether the SPEAD descriptors have been received "
                    " (prometheus: gauge)",

--- a/katsdpingest/katsdpingest/utils.py
+++ b/katsdpingest/katsdpingest/utils.py
@@ -205,11 +205,17 @@ class SensorWrapper(object):
 
     @value.setter
     def value(self, new_value):
+        self.set_value(new_value)
+
+    def set_value(self, new_value, timestamp=None):
         new_status = self._status_func(new_value)
         if new_value != self._value or new_status != self._status:
             self._value = new_value
             self._status = new_status
-            self._sensor.set_value(new_value, status=new_status)
+            self._sensor.set_value(new_value, status=new_status, timestamp=timestamp)
+
+    def increment(self, delta, timestamp=None):
+        self.set_value(self.value + delta, timestamp)
 
 
 __all__ = ['cbf_telstate_view', 'set_telstate_entry', 'Range', 'SensorWrapper']


### PR DESCRIPTION
The signal display flag counter is extended to also count the number of
visibilities per baseline with any flag bit set (in addition to the
number with each flag bit set). This is not currently wired into the
signal display SPEAD stream, but it could be. It's then summed (on the
host) to produce a single number for the total number of flagged
visibilities (output-flagged-total). Another sensor counts the
corresponding number of all visibilities (output-vis-total) so that
ratios can easily be computed for dashboards.