### PR TITLE
Explicitly depend on tornado<5

### DIFF
--- a/katsdpbfingest/setup.py
+++ b/katsdpbfingest/setup.py
@@ -90,7 +90,7 @@ setup(
         'katsdpfilewriter',
         'katsdpservices',
         'katsdptelstate',
-        'tornado',
+        'tornado<5',
         'trollius'
     ],
     extras_require={

--- a/katsdpcam2telstate/setup.py
+++ b/katsdpcam2telstate/setup.py
@@ -16,7 +16,7 @@ setup(
         'katsdpservices',
         'katsdptelstate',
         'katportalclient',
-        'tornado>=4.0',
+        'tornado>=4.0, <5',
         'six'
     ],
     use_katversion=True

--- a/katsdpingest/setup.py
+++ b/katsdpingest/setup.py
@@ -26,7 +26,7 @@ setup(
         'katsdpservices',
         'katsdptelstate',
         'trollius',
-        'tornado'
+        'tornado<5'
     ],
     extras_require={
         'test': tests_require


### PR DESCRIPTION
pip install tornado on Python 2 installs Tornado 5, for which the
trollius integration no longer works.