### PR TITLE
Add anc.tfr.ktt.gnss sensor to telstate

### DIFF
--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -203,6 +203,7 @@ SENSORS = [
     Sensor('anc_wind_direction'),
     Sensor('anc_mean_wind_speed'),
     Sensor('anc_siggen_ku_frequency'),
+    Sensor('anc_tfr_ktt_gnss'),
     Sensor('mcp_dmc_version_list', immutable=True)
 ]
 


### PR DESCRIPTION
Some info from Thomas Abbott:

This measures KTT -  GNSS [the Karoo Telescope Time offset] in
nanoseconds. The sign is usually negative. A negative number means:

* KTT is lagging GNSS - GNSS is always in front of KTT.
* Thus at an instant, the time number for KTT is smaller than the time
  number for GNSS.
* KTT reaches 12h00 AFTER GNSS if a mechanical clock indicator was
  available.

The value will drift around as TFR tune the masers. It's currently just
a few nanoseconds, I think they will try to keep it between -1000 ns
and 0 ns. It might also jump suddenly by up to 2000 ns if we switch
from Maser 1 to Maser 2.