### PR TITLE
Handle missing and out-of-order heaps in digitiser capture

### DIFF
--- a/digitiser_capture/digitiser_decode.cpp
+++ b/digitiser_capture/digitiser_decode.cpp
@@ -293,7 +293,7 @@ void writer::write(const decoded_info &heap)
     if (heap.data.size() != samples)
     {
         std::cerr << "Warning: discarding heap with " << heap.data.size()
-            << ", expected " << samples << '\n';
+            << " samples, expected " << samples << '\n';
         return;
     }
     if (!seen.insert(heap.timestamp).second)


### PR DESCRIPTION
Previously each packet was expected to immediately follow the previous
one in timestamp. Packets are now allowed to appear in any order (except
that they cannot predate the sync point), and are written at the
appropriate place (possibly creating holes in the file).

At present there is no way to know which heaps went missing, other than
to look for 4096 zeros in the file.

Closes SR-1277.