### PR TITLE
Enable flake8 and mypy testing of katsdpingest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ catchError {
     katsdp.stagePrepare(subdir: 'katsdpingest', python2: false, python3: true,
                         timeout: [time: 60, unit: 'MINUTES'])
     katsdp.stageNosetestsGpu(subdir: 'katsdpingest', cuda: true, opencl: true)
+    katsdp.stageFlake8(subdir: 'katsdpingest')
+    katsdp.stageMypy(subdir: 'katsdpingest')
     katsdp.stageMakeDocker(subdir: 'katsdpingest', venv: true)
 
     stage('katsdpingest/autotuning') {


### PR DESCRIPTION
katsdpingest uses a custom build instead of standardBuild, so it wasn't
getting the automatic flake8 and mypy checks.