### PR TITLE
Make clear that input-metadata-heaps-total is good

### DIFF
--- a/katsdpingest/katsdpingest/ingest_server.py
+++ b/katsdpingest/katsdpingest/ingest_server.py
@@ -84,7 +84,7 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
                    default=Status.INIT, initial_status=Sensor.Status.NOMINAL),
             Sensor(float, "last-dump-timestamp",
                    "Timestamp of most recently received correlator dump in Unix seconds "
-                   " (prometheus: gauge)", "s",
+                   "(prometheus: gauge)", "s",
                    default=0.0, initial_status=Sensor.Status.NOMINAL),
             Sensor(DeviceStatus, "device-status",
                    "Health status",
@@ -92,15 +92,19 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
                    status_func=_device_status_status),
             Sensor(int, "input-bytes-total",
                    "Number of payload bytes received from CBF in this session "
-                   " (prometheus: counter)",
+                   "(prometheus: counter)",
                    initial_status=Sensor.Status.NOMINAL),
             Sensor(int, "input-heaps-total",
                    "Number of payload heaps received from CBF in this session "
-                   " (prometheus: counter)",
+                   "(prometheus: counter)",
                    initial_status=Sensor.Status.NOMINAL),
             Sensor(int, "input-dumps-total",
                    "Number of CBF dumps received in this session "
-                   " (prometheus: counter)",
+                   "(prometheus: counter)",
+                   initial_status=Sensor.Status.NOMINAL),
+            Sensor(int, "input-metadata-heaps-total",
+                   "Number of heaps that do not contain payload in this session "
+                   "(prometheus: counter)",
                    initial_status=Sensor.Status.NOMINAL),
             Sensor(int, "output-bytes-total",
                    "Number of payload bytes sent on L0 in this session "

--- a/katsdpingest/katsdpingest/receiver.py
+++ b/katsdpingest/katsdpingest/receiver.py
@@ -27,7 +27,6 @@ REJECT_HEAP_TYPES = {
     'too-old': 'timestamp is prior to the start time',
     'bad-channel': 'channel offset is not aligned to the substreams',
     'missing': 'expected heap was not received',
-    'metadata': 'heap without payload e.g. descriptor or start-of-stream'
 }
 
 
@@ -161,6 +160,8 @@ class Receiver:
         self._input_dumps.value = 0
         self._descriptors_received = sensors['descriptors-received']
         self._descriptors_received.value = False
+        self._metadata_heaps = sensors['input-metadata-heaps-total']
+        self._metadata_heaps.value = 0
         self._reject_heaps = {
             name: sensors['input-' + name + '-heaps-total'] for name in REJECT_HEAP_TYPES
         }
@@ -321,7 +322,7 @@ class Receiver:
                 except spead2.Stopped:
                     break
                 if heap.is_end_of_stream():
-                    self._reject_heaps['metadata'].value += 1
+                    self._metadata_heaps.value += 1
                     n_stop += 1
                     _logger.debug("%d/%d endpoints stopped on stream %d",
                                   n_stop, n_endpoints, stream_idx)
@@ -351,7 +352,7 @@ class Receiver:
                     self._descriptors_received.value = True
                 if 'xeng_raw' not in updated:
                     _logger.debug("CBF non-data heap received on stream %d", stream_idx)
-                    self._reject_heaps['metadata'].value += 1
+                    self._metadata_heaps.value += 1
                     continue
                 if 'timestamp' not in updated:
                     _logger.warning("CBF heap without timestamp received on stream %d", stream_idx)


### PR DESCRIPTION
Because it was bundled into the REJECT_HEAPS machinery, non-zero values
were reported as warnings in katcp, and the sensor description also
sounded bad. Split it out of REJECT_HEAPS and manage it separately.

Closes SR-1329.