### PR TITLE
Improve synchronisation between ingests

### DIFF
--- a/katsdpingest/katsdpingest/test/test_receiver.py
+++ b/katsdpingest/katsdpingest/test/test_receiver.py
@@ -185,7 +185,8 @@ class TestReceiver(asynctest.TestCase):
         xeng_raw, indices, timestamps = self._make_data(n_frames)
         send_future = self.loop.create_task(self._send_out_of_order(xeng_raw, timestamps))
         try:
-            for t, missing in [(0, []), (1, []), (2, [0, 1, 3]), (6, []), (8, [])]:
+            for t, missing in [(0, []), (1, []), (2, [0, 1, 3]), (6, []),
+                               (7, [1, 2, 3]), (8, []), (9, [1])]:
                 with async_timeout.timeout(3, loop=self.loop):
                     frame = await self.rx.get()
                 assert_equal(indices[t], frame.idx)


### PR DESCRIPTION
- Remove _flush_frames, which would eagerly flush out frames once
  complete, but would cause ingests to run out of sync if some ingests
  didn't get all the data while others did. This will improve
  synchronisation at the expense of latency (by about active_frames-1
  dumps).
- Change active_frames from 4 to 1, to reduce the impact of the latency
  increase above (1 was recommended by @jmanley).
- Unify the handling of popped frames between the main loop and the
  handling of the left-over dumps at stop time. The latter used to
  discard partial frames, and didn't update the missing heaps counter.
  I'm not sure why it discarded partial heaps - possibly to avoid a
  ragged end of file when katdal couldn't cope with missing heaps.

Addresses MKAIV-1288.