### PR TITLE
Avoid storing types and dtypes in telstate

### DIFF
--- a/katsdpingest/katsdpingest/ingest_session.py
+++ b/katsdpingest/katsdpingest/ingest_session.py
@@ -160,7 +160,7 @@ def _fix_descriptions(desc):
     elif isinstance(desc, tuple):
         return tuple([_fix_descriptions(item) for item in desc])
     elif isinstance(desc, set):
-        return {fix_descriptions(item) for item in desc}
+        return {_fix_descriptions(item) for item in desc}
     elif isinstance(desc, dict):
         return OrderedDict(sorted(_fix_descriptions(item) for item in desc.items()))
     elif isinstance(desc, np.dtype):


### PR DESCRIPTION
The process log stored in telstate contained some dtypes and some Python
types (I think most if not all were actually types like np.int8 that
were pseudo-dtypes). Anything that looks like a potential dtype is not
converted to its descriptor, and other types are stringified, so that
the data can be encoded into less general data models than pickle (e.g.
msgpack).