### PR TITLE
Capture the new beam weight sensor

### DIFF
--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -184,7 +184,12 @@ SENSORS = [
     Sensor('${stream.cbf.baseline_correlation_products}_n_chans_per_substream', immutable=True),
     Sensor('${sub_stream.cbf.tied_array_channelised_voltage}_bandwidth', immutable=True),
     Sensor('${stream.cbf.tied_array_channelised_voltage}_n_chans', immutable=True),
-    Sensor('${stream.cbf.tied_array_channelised_voltage.inputn}_weight'),
+    Sensor('${stream.cbf.tied_array_channelised_voltage}_source_indices',
+           immutable=True, convert=np.safe_eval),
+    Sensor('${stream.cbf.tied_array_channelised_voltage.inputn}_weight',
+           ignore_missing=True),   # CBF-CAM ICD v5 - remove in future
+    Sensor('${stream.cbf.tied_array_channelised_voltage}_weight',
+           ignore_missing=True, convert=np.safe_eval),   # CBF-CAM ICD v6 (draft)
     Sensor('${stream.cbf.tied_array_channelised_voltage}_n_chans_per_substream', immutable=True),
     Sensor('${stream.cbf.tied_array_channelised_voltage}_spectra_per_heap', immutable=True),
     Sensor('${stream.cbf.antenna_channelised_voltage}_n_samples_between_spectra',


### PR DESCRIPTION
The (yet-to-be-defined) CBF-CAM ICD v6 changes the beam weight sensors
from a float sensor per input to a list sensor per stream. Capture both
the old and new versions (whichever is provided). Also capture the
source-indices since that's needed to match each weight to a
corresponding input.

Closes SR-1406.