### PR TITLE
Encode unicode to UTF-8 in telescope model

### DIFF
--- a/katsdpbfingest/katsdpbfingest/file_writer.py
+++ b/katsdpbfingest/katsdpbfingest/file_writer.py
@@ -28,6 +28,16 @@ def _array_encode(value: Any) -> Any:
         return value
 
 
+def _fromrecords(reclist, names):
+    """Convert array of records to array for writing to HDF5.
+
+    This is similar to :func:`np.rec.fromrecords` (in limited form), but any
+    fields containing Unicode are encoded as UTF-8.
+    """
+    fields = [_array_encode(field) for field in zip(*reclist)]
+    return np.rec.fromarrays(fields, names=names)
+
+
 def set_telescope_model(h5_file: h5py.File,
                         model_data: TelescopeModelData,
                         base_path: str = "/TelescopeModel") -> None:
@@ -53,7 +63,7 @@ def set_telescope_model(h5_file: h5py.File,
                 data = model_data.get_sensor_values(sensor)
                 if data is not None:
                     try:
-                        dset = np.rec.fromrecords(data, names='timestamp, value, status')
+                        dset = _fromrecords(data, names='timestamp, value, status')
                         dset.sort(axis=0)
                         c_group.create_dataset(sensor.name, data=dset)
                         if sensor.description is not None:


### PR DESCRIPTION
bfingest still has legacy telescope model code hanging around. It was
raising exceptions when storing sensors if the values were unicode
strings (and also because the status was Python 3 str). Add a shim to
pass fields through `_array_encode` to encode them to UTF-8.

This isn't perfect because Python 3 code won't decode it again on load
(it'll remain in numpy 'S' type). But since the telescope model is
legacy it's probably not worth mucking about trying to get the right
h5py custom data type incantations.