### PR TITLE
Portal error handling

### DIFF
--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -443,7 +443,7 @@ class Client(object):
         except Exception as e:
             if isinstance(e, katportalclient.SensorLookupError):
                 self._logger.error("Sensor name lookup failed. Please check the state of "
-                                   "the CAM sensor portal to make sure it is not in error. (%s)", e)
+                                   "the CAM subarray to make sure it is not in error. (%s)", e)
             else:
                 self._logger.error("Exception during startup", exc_info=True)
             if self._device_server is not None:


### PR DESCRIPTION
This is to deliver a less cryptic message when the CAM sensor portal is in an error state. Currently you end up with something like the following:

2018-12-16T13:47:14.066Z - cam2telstate.py:444 - ERROR - Exception during startup
Traceback (most recent call last):
  File "/home/kat/ve/bin/cam2telstate.py", line 399, in start
    self._sub_name = yield self._portal_client.sensor_subarray_lookup('sub', '')
  File "/home/kat/ve/local/lib/python2.7/site-packages/tornado/gen.py", line 1055, in run
    value = future.result()
  File "/home/kat/ve/local/lib/python2.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "/home/kat/ve/local/lib/python2.7/site-packages/tornado/gen.py", line 1069, in run
    yielded = self.gen.send(value)
  File "/home/kat/ve/local/lib/python2.7/site-packages/katportalclient/client.py", line 1771, in sensor_subarray_lookup
    raise SensorLookupError(data['error'])
SensorLookupError: InvalidState: sensor_name_lookup() cannot be called in 'error' state, only in these states: ('active', 'initialising')

This will special case this error and produce:

2018-12-16T13:47:14.066Z - cam2telstate.py:444 - ERROR - Sensor name lookup failed. Please check the state of hte CAM sensor portal to make sure it is not in error. (InvalidState: sensor_name_lookup() cannot be called in 'error' state, only in these states: ('active', 'initialising'))

which hopefully allows easier operator debugging.