### PR TITLE
A few trivial changes to keep mypy happy

### DIFF
--- a/katsdpbfingest/katsdpbfingest/test/test_bf_ingest_server.py
+++ b/katsdpbfingest/katsdpbfingest/test/test_bf_ingest_server.py
@@ -244,7 +244,7 @@ class TestCaptureServer(asynctest.TestCase):
         assert_equal(n_heaps // self.heaps_per_stats + 2, len(heaps))
         assert_true(heaps[0].is_start_of_stream())
         assert_true(heaps[-1].is_end_of_stream())
-        ig = spead2.ItemGroup()
+        ig = spead2.send.ItemGroup()
         spectrum = 0
         spectra_per_stats = self.heaps_per_stats * self.spectra_per_heap
         for heap in heaps[1:-1]:

--- a/katsdpingest/katsdpingest/ingest_session.py
+++ b/katsdpingest/katsdpingest/ingest_session.py
@@ -1459,8 +1459,8 @@ class CBFIngest:
         for (name, tx) in self.tx.items():
             logger.info('Stopping %s tx stream...', name)
             await tx.stop()
-        for tx in self._sdisp_ips.values():
+        for sdisp_tx in self._sdisp_ips.values():
             logger.info('Stopping signal display stream...')
-            await self._stop_stream(tx, self.ig_sd)
+            await self._stop_stream(sdisp_tx, self.ig_sd)
         logger.info("CBF ingest complete")
         self.status_sensor.value = Status.COMPLETE


### PR DESCRIPTION
In a couple of places, the same variable is used first for one type then
for another, which mypy objects to.