### PR TITLE
Decode strings received from katportalclient

### DIFF
--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -41,12 +41,10 @@ def recursive_decode(value, encoding):
     """Decode byte strings to unicode, recursing on lists, tuples and dicts"""
     if isinstance(value, bytes):
         return value.decode(encoding)
-    elif isinstance(value, list):
-        return [recursive_decode(item, encoding) for item in value]
-    elif isinstance(value, tuple):
-        return tuple(recursive_decode(item, encoding) for item in value)
+    elif isinstance(value, (list, tuple)):
+        return type(value)(recursive_decode(item, encoding) for item in value)
     elif isinstance(value, dict):
-        return dict([recursive_decode(item, encoding) for item in value.items()])
+        return type(value)(recursive_decode(item, encoding) for item in value.items())
     else:
         return value
 


### PR DESCRIPTION
With the switch of telstate to msgpack, bytes vs strings gets preserved
more exactly, which leads to things like ingest getting confused by
finding bytes when it expects strings (all of which is thanks to
katportalclient being Py2-only).

Recursively decode all byte strings as UTF-8. There is an option to
override the decoding on a specific sensor if we ever need to store
binary blobs. Numpy arrays do not get converted.