### PR TITLE
Remove instrument bandwidth sensor

### DIFF
--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -168,9 +168,8 @@ SENSORS = [
     Sensor('${cbf}_cmc_version_list', immutable=True),
     # SDP proxy sensors
     Sensor('${sdp}_spmc_version_list', immutable=True),
-    # CBF sensors that are instrument specific
+    # CBF sensors that are instrument-specific
     Sensor('${instrument}_adc_sample_rate', immutable=True),
-    Sensor('${instrument}_bandwidth', immutable=True),
     Sensor('${instrument}_n_inputs', immutable=True),
     Sensor('${instrument}_scale_factor_timestamp', immutable=True),
     Sensor('${instrument}_sync_time', immutable=True),


### PR DESCRIPTION
For narrowband it will be the CBF input bandwidth, which we don't care
about. It is (hopefully) not being used anyway, because we subscribe to
stream-specific bandwidth sensors.