### PR TITLE
Take per-visibility flags as input 

### DIFF
--- a/katsdpingest/katsdpingest/ingest_kernels/merge_flags.mako
+++ b/katsdpingest/katsdpingest/ingest_kernels/merge_flags.mako
@@ -1,0 +1,31 @@
+<%include file="/port.mako"/>
+<%namespace name="transpose" file="/transpose_base.mako"/>
+
+<%transpose:transpose_data_class class_name="transpose_flags" type="uchar" block="${block}" vtx="${vtx}" vty="${vty}"/>
+<%transpose:transpose_coords_class class_name="transpose_coords" block="${block}" vtx="${vtx}" vty="${vty}"/>
+
+KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void merge_flags(
+    GLOBAL uchar * RESTRICT out_flags,
+    const GLOBAL uchar * RESTRICT in_flags,
+    const GLOBAL uchar * RESTRICT baseline_flags,
+    int out_flags_stride,
+    int in_flags_stride)
+{
+    LOCAL_DECL transpose_flags local_flags;
+    transpose_coords coords;
+    transpose_coords_init_simple(&coords);
+
+    // Load input flags into shared memory
+    <%transpose:transpose_load coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
+        int addr = ${r} * in_flags_stride + ${c};
+        local_flags.arr[${lr}][${lc}] = in_flags[addr];
+    </%transpose:transpose_load>
+
+    BARRIER();
+
+    // Combine with output and baseline flags
+    <%transpose:transpose_store coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
+        int addr = ${r} * out_flags_stride + ${c};
+        out_flags[addr] |= local_flags.arr[${lr}][${lc}] | baseline_flags[${r}];
+    </%transpose:transpose_store>
+}

--- a/katsdpingest/katsdpingest/sigproc.py
+++ b/katsdpingest/katsdpingest/sigproc.py
@@ -189,6 +189,133 @@ class Prepare(accel.Operation):
         }
 
 
+class MergeFlagsTemplate:
+    """Template for combining several sources of flags.
+
+    Combines:
+    - Per-baseline flags, provided externally
+    - Per-visibility flags (in channel × baseline shape), used as input to the flagger
+    - Per-visibility flags (in baseline × channel shape), output by the flagger.
+    The result is written back into the last of these.
+
+    Parameters
+    ----------
+    context : |Context|
+        Context for which kernels will be compiled
+    tuning : mapping, optional
+        Kernel tuning parameters; if omitted, will autotune. The possible
+        parameters are
+
+        - block: number of workitems per workgroup in each dimension
+        - vtx, vty: number of elements handled by each workitem, per dimension
+    """
+    autotune_version = 1
+
+    def __init__(self, context, tuning=None):
+        if tuning is None:
+            tuning = self.autotune(context)
+        self.context = context
+        self.block = tuning['block']
+        self.vtx = tuning['vtx']
+        self.vty = tuning['vty']
+        program = accel.build(
+            context, 'ingest_kernels/merge_flags.mako',
+            {'block': self.block, 'vtx': self.vtx, 'vty': self.vty},
+            extra_dirs=[pkg_resources.resource_filename(__name__, '')])
+        self.kernel = program.get_kernel('merge_flags')
+
+    @classmethod
+    @tune.autotuner(test={'block': 16, 'vtx': 2, 'vty': 3})
+    def autotune(cls, context):
+        queue = context.create_tuning_command_queue()
+        baselines = 1024
+        channels = 2048
+
+        flags_in = accel.DeviceArray(context, (channels, baselines), np.uint8)
+        flags_out = accel.DeviceArray(context, (baselines, channels), np.uint8)
+        baseline_flags = accel.DeviceArray(context, (baselines,), np.uint8)
+
+        def generate(block, vtx, vty):
+            fn = cls(context, {
+                'block': block,
+                'vtx': vtx,
+                'vty': vty}).instantiate(queue, channels, baselines)
+            fn.bind(flags_in=flags_in, flags_out=flags_out, baseline_flags=baseline_flags)
+            return tune.make_measure(queue, fn)
+        return tune.autotune(
+            generate,
+            block=[8, 16, 32],
+            vtx=[1, 2, 3, 4],
+            vty=[1, 2, 3, 4])
+
+    def instantiate(self, command_queue, channels, baselines):
+        return MergeFlags(self, command_queue, channels, baselines)
+
+
+class MergeFlags(accel.Operation):
+    """Concrete instance of :class:`MergeFlagsTemplate`.
+
+    .. rubric:: Slots
+
+    **flags_in** : channels × baselines, uint8
+        One set of flags to merge
+    **flags_out** : baselines × channels, uint8
+        Another set of flags to merge, and also the output
+    **baseline_flags** : baselines, uint8
+        Per-baseline flags to merge with the others
+
+    Parameters
+    ----------
+    template : :class:`MergeFlagsTemplate`
+        Template containing the code
+    command_queue : |CommandQueue|
+        Command queue for the operation
+    channels : int
+        Number of channels
+    baselines : int
+        Number of baselines
+    """
+    def __init__(self, template, command_queue, channels, baselines):
+        super().__init__(command_queue)
+        self.template = template
+        self.channels = channels
+        self.baselines = baselines
+        tilex = template.block * template.vtx
+        tiley = template.block * template.vty
+        padded_channels = accel.Dimension(channels, tiley)
+        padded_baselines = accel.Dimension(baselines, tilex)
+        self.slots['flags_in'] = accel.IOSlot((padded_channels, padded_baselines), np.uint8)
+        self.slots['flags_out'] = accel.IOSlot((padded_baselines, padded_channels), np.uint8)
+        self.slots['baseline_flags'] = accel.IOSlot((padded_baselines,), np.uint8)
+
+    def _run(self):
+        flags_in = self.buffer('flags_in')
+        flags_out = self.buffer('flags_out')
+        baseline_flags = self.buffer('baseline_flags')
+        block = self.template.block
+        tilex = block * self.template.vtx
+        tiley = block * self.template.vty
+        xblocks = accel.divup(self.baselines, tilex)
+        yblocks = accel.divup(self.channels, tiley)
+        self.command_queue.enqueue_kernel(
+            self.template.kernel,
+            [
+                flags_out.buffer,
+                flags_in.buffer,
+                baseline_flags.buffer,
+                np.int32(flags_out.padded_shape[1]),
+                np.int32(flags_in.padded_shape[1])
+            ],
+            global_size=(xblocks * block, yblocks * block),
+            local_size=(block, block))
+
+    def parameters(self):
+        return {
+            'channels': self.channels,
+            'baselines': self.baselines
+        }
+
+
 class CountFlagsTemplate:
     """Template for counting the number of flags of each type.
 
@@ -206,7 +333,8 @@ class CountFlagsTemplate:
 
         - wgs: number of workitems per workgroup in channel dimension
     """
-    autotune_version = 1
+
+    autotune_version = 2
 
     def __init__(self, context, tuning=None):
         if tuning is None:
@@ -252,10 +380,6 @@ class CountFlags(accel.Operation):
 
     **flags** : baselines × channels, uint8
         Input flags
-    **channel_flags** : channels, uint8
-        Extra flags applied per channel
-    **baseline_flags** : baselines, uint8
-        Extra flags applied per baseline
     **counts** : baselines × 8, uint32
         Number of times each bit is set per baseline. Bits are counted
         from the LSB.
@@ -277,6 +401,7 @@ class CountFlags(accel.Operation):
     mask : int
         Mask of flag bits to count
     """
+
     def __init__(self, template, command_queue, channels, channel_range, baselines, mask=0xff):
         super().__init__(command_queue)
         self.template = template
@@ -286,8 +411,6 @@ class CountFlags(accel.Operation):
         self.mask = mask
         bits = accel.Dimension(8, exact=True)
         self.slots['flags'] = accel.IOSlot((baselines, channels), np.uint8)
-        self.slots['channel_flags'] = accel.IOSlot((channels,), np.uint8)
-        self.slots['baseline_flags'] = accel.IOSlot((baselines,), np.uint8)
         self.slots['counts'] = accel.IOSlot((baselines, bits), np.uint32)
         self.slots['any_counts'] = accel.IOSlot((baselines,), np.uint32)
 
@@ -300,8 +423,6 @@ class CountFlags(accel.Operation):
                 counts.buffer,
                 any_counts.buffer,
                 flags.buffer,
-                self.buffer('channel_flags').buffer,
-                self.buffer('baseline_flags').buffer,
                 np.int32(flags.padded_shape[1]),
                 np.int32(len(self.channel_range)),
                 np.int32(self.channel_range.start),
@@ -344,7 +465,8 @@ class AccumTemplate:
         - block: number of workitems per workgroup in each dimension
         - vtx, vty: number of elements handled by each workitem, per dimension
     """
-    autotune_version = 2
+
+    autotune_version = 3
 
     def __init__(self, context, outputs, unflagged_bit, excise, tuning=None):
         if tuning is None:
@@ -364,7 +486,8 @@ class AccumTemplate:
                 'vty': self.vty,
                 'unflagged_bit': self.unflagged_bit,
                 'excise': self.excise,
-                'outputs': self.outputs},
+                'outputs': self.outputs
+            },
             extra_dirs=[pkg_resources.resource_filename(__name__, '')])
         self.kernel = program.get_kernel('accum')
 
@@ -430,10 +553,6 @@ class Accum(accel.Operation):
         Input weights
     **flags_in** : baselines × channels, uint8
         Input flags: non-zero values cause downweighting by 2^-64
-    **channel_flags** : channels, uint8
-        Predetermined flags per channel
-    **baseline_flags** : baselines, uint8
-        Predetermined flags per baseline
     **vis_outN** : kept-channels × baselines, complex64
         Incremented by weight × visibility
     **weights_outN** : kept-channels × baselines, float32
@@ -480,15 +599,6 @@ class Accum(accel.Operation):
             (padded_baselines, padded_kept_channels), np.float32)
         self.slots['flags_in'] = accel.IOSlot(
             (padded_baselines, padded_channels), np.uint8)
-        # The minimum padded size for channel_flags is tricky because it is
-        # the kept-channels part that needs to be aligned to be a multiple of
-        # tilex.
-        channel_flags_size = max(channels,
-                                 accel.roundup(kept_channels, tilex) + channel_range.start)
-        self.slots['channel_flags'] = accel.IOSlot(
-            (accel.Dimension(channels, min_padded_size=channel_flags_size),), np.uint8)
-        self.slots['baseline_flags'] = accel.IOSlot(
-            (accel.Dimension(baselines, tiley),), np.uint8)
         for i in range(self.template.outputs):
             label = str(i)
             self.slots['vis_out' + label] = accel.IOSlot(
@@ -503,12 +613,12 @@ class Accum(accel.Operation):
         for i in range(self.template.outputs):
             label = str(i)
             buffer_names.extend(['vis_out' + label, 'weights_out' + label, 'flags_out' + label])
-        buffer_names.extend(['vis_in', 'weights_in', 'flags_in', 'channel_flags', 'baseline_flags'])
+        buffer_names.extend(['vis_in', 'weights_in', 'flags_in'])
         buffers = [self.buffer(x) for x in buffer_names]
         args = [x.buffer for x in buffers] + [
             np.int32(buffers[0].padded_shape[1]),
-            np.int32(buffers[-5].padded_shape[1]),
-            np.int32(buffers[-4].padded_shape[1]),
+            np.int32(buffers[-3].padded_shape[1]),
+            np.int32(buffers[-2].padded_shape[1]),
             np.int32(self.channel_range.start)]
 
         kept_channels = len(self.channel_range)
@@ -966,6 +1076,7 @@ class IngestTemplate:
         self.transpose_vis = transpose.TransposeTemplate(
             context, np.complex64, 'float2')
         self.flagger = flagger
+        self.merge_flags = MergeFlagsTemplate(context)
         self.count_flags = CountFlagsTemplate(context)
         # We need a spare bit that won't be present in any actual flags. Since
         # cal RFI detection happens later in the pipeline, it is definitely
@@ -1008,8 +1119,8 @@ class IngestOperation(accel.OperationSequence):
 
     **vis_in** : channels × baselines × 2, int32
         Input visibilities from the correlator
-    **channel_flags** : channels, uint8
-        Predefined per-channel flags
+    **flags_in** : channels × baselines, uint8
+        Predefined per-visibility flags, with post-permutation baseline ordering
     **baseline_flags** : baselines, uint8
         Predefined per-baseline flags, in the post-permutation ordering
     **permutation** : baselines, int16
@@ -1117,6 +1228,8 @@ class IngestOperation(accel.OperationSequence):
             command_queue, (baselines, channels))
         self.flagger = template.flagger.instantiate(
             command_queue, channels, baselines, background_args, noise_est_args, threshold_args)
+        self.merge_flags = template.merge_flags.instantiate(
+            command_queue, channels, baselines)
         self.count_flags = template.count_flags.instantiate(
             command_queue, channels, count_flags_channel_range, baselines,
             0xff - self.template.accum.unflagged_bit)
@@ -1175,6 +1288,7 @@ class IngestOperation(accel.OperationSequence):
             ('zero_sd_spec', self.zero_sd_spec),
             ('transpose_vis', self.transpose_vis),
             ('flagger', self.flagger),
+            ('merge_flags', self.merge_flags),
             ('count_flags', self.count_flags),
             ('accum', self.accum),
             ('finalise', self.finalise),
@@ -1187,20 +1301,21 @@ class IngestOperation(accel.OperationSequence):
             operations.append((name, self.percentiles[i]))
             operations.append((name + '_flags', self.percentiles_flags[i]))
 
-        # TODO: eliminate transposition of flags, which aren't further used
+        # TODO: eliminate final transposition of flags by the flagger, which
+        # aren't further used.
         assert 'flags_t' in self.flagger.slots
         compounds = {
             'vis_in':         ['prepare:vis_in'],
-            'channel_flags':  ['flagger:input_flags',
-                               'accum:channel_flags', 'count_flags:channel_flags'],
-            'baseline_flags': ['accum:baseline_flags', 'count_flags:baseline_flags'],
+            'flags_in':       ['flagger:input_flags', 'merge_flags:flags_in'],
+            'baseline_flags': ['merge_flags:baseline_flags'],
             'permutation':    ['prepare:permutation'],
             'vis_t':          ['prepare:vis_out', 'transpose_vis:src', 'accum:vis_in'],
             'weights':        ['init_weights:data', 'accum:weights_in'],
             'vis_mid':        ['transpose_vis:dest', 'flagger:vis'],
             'deviations':     ['flagger:deviations'],
             'noise':          ['flagger:noise'],
-            'flags':          ['flagger:flags_t', 'accum:flags_in', 'count_flags:flags'],
+            'flags':          ['flagger:flags_t', 'accum:flags_in', 'count_flags:flags',
+                               'merge_flags:flags_out'],
             'sd_flag_counts': ['count_flags:counts'],
             'sd_flag_any_counts': ['count_flags:any_counts'],
             'spec_vis':       ['accum:vis_out0', 'zero_spec:vis'],
@@ -1256,6 +1371,7 @@ class IngestOperation(accel.OperationSequence):
         self.init_weights()
         self.transpose_vis()
         self.flagger()
+        self.merge_flags()
         # The per-bit flags are sent to the signal displays, so are
         # accumulated across signal display intervals. The overall flagged
         # count is done at CBF cadence so they're reset here immediately

--- a/katsdpingest/katsdpingest/sigproc.py
+++ b/katsdpingest/katsdpingest/sigproc.py
@@ -1191,8 +1191,8 @@ class IngestOperation(accel.OperationSequence):
         assert 'flags_t' in self.flagger.slots
         compounds = {
             'vis_in':         ['prepare:vis_in'],
-            'channel_flags':  ['flagger:channel_flags', 'accum:channel_flags',
-                               'count_flags:channel_flags'],
+            'channel_flags':  ['flagger:input_flags',
+                               'accum:channel_flags', 'count_flags:channel_flags'],
             'baseline_flags': ['accum:baseline_flags', 'count_flags:baseline_flags'],
             'permutation':    ['prepare:permutation'],
             'vis_t':          ['prepare:vis_out', 'transpose_vis:src', 'accum:vis_in'],

--- a/katsdpingest/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/katsdpingest/test/test_sigproc.py
@@ -439,7 +439,8 @@ class TestIngestOperation:
             ('ingest:flagger', {'class': 'katsdpsigproc.rfi.device.FlaggerDevice'}),
             ('ingest:flagger:background', {
                 'baselines': 192, 'channels': 128,
-                'class': 'katsdpsigproc.rfi.device.BackgroundMedianFilterDevice', 'width': 13
+                'class': 'katsdpsigproc.rfi.device.BackgroundMedianFilterDevice',
+                'use_flags': 'NONE', 'width': 13
             }),
             ('ingest:flagger:transpose_deviations', {
                 'class': 'katsdpsigproc.transpose.Transpose',

--- a/katsdpingest/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/katsdpingest/test/test_sigproc.py
@@ -86,6 +86,32 @@ class TestPrepare:
         sigproc.PrepareTemplate(context)
 
 
+class TestMergeFlags:
+    """Test :class:`katsdpingest.sigproc.MergeFlags`"""
+
+    @device_test
+    def test_random(self, context, queue):
+        """Basic test using random data"""
+        channels = 643
+        baselines = 497
+        rs = np.random.RandomState(seed=1)
+        flags_in = random_flags(rs, (channels, baselines), 8, 0.1)
+        flags_out = random_flags(rs, (baselines, channels), 8, 0.1)
+        baseline_flags = random_flags(rs, (baselines,), 8, 0.2)
+
+        template = sigproc.MergeFlagsTemplate(context)
+        fn = template.instantiate(queue, channels, baselines)
+        fn.ensure_all_bound()
+        fn.buffer('flags_in').set(queue, flags_in)
+        fn.buffer('flags_out').set(queue, flags_out)
+        fn.buffer('baseline_flags').set(queue, baseline_flags)
+        fn()
+        output = fn.buffer('flags_out').get(queue)
+
+        expected = flags_out | flags_in.T | baseline_flags[:, np.newaxis]
+        np.testing.assert_equal(expected, output)
+
+
 class TestCountFlags:
     """Test :class:`katsdpingest.sigproc.CountFlags`"""
 
@@ -99,8 +125,6 @@ class TestCountFlags:
 
         rs = np.random.RandomState(seed=1)
         flags = rs.randint(0, 256, size=(baselines, channels)).astype(np.uint8)
-        baseline_flags = random_flags(rs, (baselines,), 2, 0.05)
-        channel_flags = random_flags(rs, (channels,), 3, 0.05)
         orig_counts = rs.randint(0, 10000, size=(baselines, 8)).astype(np.uint32)
         orig_any_counts = rs.randint(0, 10000, size=baselines).astype(np.uint32)
 
@@ -110,16 +134,13 @@ class TestCountFlags:
         fn.buffer('flags').set(queue, flags)
         fn.buffer('counts').set(queue, orig_counts)
         fn.buffer('any_counts').set(queue, orig_any_counts)
-        fn.buffer('baseline_flags').set(queue, baseline_flags)
-        fn.buffer('channel_flags').set(queue, channel_flags)
         fn()
         counts = fn.buffer('counts').get(queue)
         any_counts = fn.buffer('any_counts').get(queue)
 
         assert_equal((baselines, 8), counts.shape)
         expected = orig_counts[:]
-        combined_flags = flags | baseline_flags[:, np.newaxis] | channel_flags[np.newaxis, :]
-        combined_flags &= mask
+        combined_flags = flags & mask
         included_flags = combined_flags[:, channel_range.asslice()]
         for i in range(8):
             expected[:, i] += np.count_nonzero(included_flags & (1 << i), axis=1).astype(np.uint32)
@@ -147,8 +168,6 @@ class TestAccum:
             'vis_in':         np.array([[1+2j, 2+5j, 3-3j, 2+1j, 4]], dtype=np.complex64),
             'weights_in':     np.array([[2.0, 4.0, 3.0]], dtype=np.float32),
             'flags_in':       np.array([[5, 0, 10, 0, 4]], dtype=np.uint8),
-            'channel_flags':  np.array([0, 2, 0, 0, 2], dtype=np.uint8),
-            'baseline_flags': np.array([0], dtype=np.uint8),
             'vis_out0':       np.array([[7-3j, 0+0j, 0+5j]], dtype=np.complex64).T,
             'weights_out0':   np.array([[1.5, 0.0, 4.5]], dtype=np.float32).T,
             'flags_out0':     np.array([[1 | unflagged, 9, unflagged]], dtype=np.uint8).T
@@ -168,9 +187,9 @@ class TestAccum:
     def test_small_excise(self, context, queue):
         """Hand-coded test data, to test various cases, with excision"""
         expected = {
-            'vis_out0':     np.array([[7-3j, (12-12j) * FLAG_SCALE, 6+8j]], dtype=np.complex64).T,
-            'weights_out0': np.array([[1.5, 4.0 * FLAG_SCALE, 7.5]], dtype=np.float32).T,
-            'flags_out0':   np.array([[3 | UNFLAGGED_BIT, 11, UNFLAGGED_BIT]], dtype=np.uint8).T
+            'vis_out0':     np.array([[11+7j, (12-12j) * FLAG_SCALE, 6+8j]], dtype=np.complex64).T,
+            'weights_out0': np.array([[3.5, 4.0 * FLAG_SCALE, 7.5]], dtype=np.float32).T,
+            'flags_out0':   np.array([[1 | UNFLAGGED_BIT, 11, UNFLAGGED_BIT]], dtype=np.uint8).T
         }
         self._test_small(context, queue, True, expected)
 
@@ -179,7 +198,7 @@ class TestAccum:
         expected = {
             'vis_out0':     np.array([[11+7j, 12-12j, 6+8j]], dtype=np.complex64).T,
             'weights_out0': np.array([[3.5, 4.0, 7.5]], dtype=np.float32).T,
-            'flags_out0':   np.array([[3, 11, 0]], dtype=np.uint8).T
+            'flags_out0':   np.array([[1, 11, 0]], dtype=np.uint8).T
         }
         self._test_small(context, queue, False, expected)
 
@@ -194,8 +213,6 @@ class TestAccum:
         vis_in = random_vis(rs, (baselines, channels))
         weights_in = rs.uniform(size=(baselines, kept_channels)).astype(np.float32)
         flags_in = random_flags(rs, (baselines, channels), 7, p=0.2)
-        channel_flags = random_flags(rs, (channels,), 7, p=0.02)
-        baseline_flags = random_flags(rs, (baselines,), 7, p=0.01)
         vis_out = []
         weights_out = []
         flags_out = []
@@ -214,8 +231,7 @@ class TestAccum:
         fn = template.instantiate(queue, channels, channel_range, baselines)
         fn.ensure_all_bound()
         for (name, value) in [('vis_in', vis_in), ('weights_in', weights_in),
-                              ('flags_in', flags_in), ('channel_flags', channel_flags),
-                              ('baseline_flags', baseline_flags)]:
+                              ('flags_in', flags_in)]:
             fn.buffer(name).set(queue, value)
         for (name, value) in [('vis_out', vis_out), ('weights_out', weights_out),
                               ('flags_out', flags_out)]:
@@ -225,17 +241,16 @@ class TestAccum:
 
         # Perform the operation on the host
         kept_vis = vis_in[:, channel_range.start : channel_range.stop]
-        kept_flags = flags_in[:, channel_range.start : channel_range.stop] \
-            | channel_flags[np.newaxis, channel_range.start : channel_range.stop] \
-            | baseline_flags[:, np.newaxis]
+        kept_flags = flags_in[:, channel_range.start : channel_range.stop]
         if excise:
             flagged_weights = weights_in * ((kept_flags == 0) + FLAG_SCALE)
             # unflagged inputs need the UNFLAGGED_BIT set
-            kept_flags |= np.where(kept_flags, 0, UNFLAGGED_BIT).astype(np.uint8)
+            kept_flags = kept_flags | np.where(kept_flags, 0, UNFLAGGED_BIT).astype(np.uint8)
         else:
             flagged_weights = weights_in
         for i in range(outputs):
-            vis_out[i] += (kept_vis * flagged_weights).T
+            # The GPU uses an FMA - simulate it by computing in double precision first
+            vis_out[i][:] = vis_out[i] + (kept_vis.astype(np.complex128) * flagged_weights).T
             weights_out[i] += flagged_weights.T
             flags_out[i] |= kept_flags.T
 
@@ -460,6 +475,10 @@ class TestIngestOperation:
                 'class': 'katsdpsigproc.transpose.Transpose',
                 'ctype': 'unsigned char', 'dtype': 'uint8', 'shape': (192, 128)
             }),
+            ('ingest:merge_flags', {
+                'channels': 128, 'baselines': 192,
+                'class': 'katsdpingest.sigproc.MergeFlags'
+            }),
             ('ingest:count_flags', {
                 'channels': 128, 'baselines': 192, 'channel_range': (8, 104),
                 'class': 'katsdpingest.sigproc.CountFlags', 'mask': 191
@@ -535,7 +554,7 @@ class TestIngestOperation:
         weights = (weights * inv_weights_channel[..., np.newaxis]).astype(np.uint8)
         return vis, flags, weights, weights_channel
 
-    def run_host_basic(self, vis, channel_flags, baseline_flags, n_accs, permutation,
+    def run_host_basic(self, vis, flags, baseline_flags, n_accs, permutation,
                        cont_factor, channel_range, count_flags_channel_range, n_sigma, excise):
         """Simple CPU implementation. All inputs and outputs are channel-major.
         There is no support for separate cadences for main and signal display
@@ -547,8 +566,8 @@ class TestIngestOperation:
         ----------
         vis : array-like
             Input dump visibilities (first axis being time)
-        channel_flags : array-like
-            Input per-channel flags (indexed by time and channel)
+        flags : array-like
+            Input per-channel flags (indexed by time, channel and post-permutation baseline)
         baseline_flags : array-like
             Input per-baseline flags (indexed by time and post-permutation baseline)
         n_accs : int
@@ -594,11 +613,9 @@ class TestIngestOperation:
         # Compute initial weights
         weights[:] = np.float32(n_accs)
         # Compute flags
-        flags = np.empty(vis.shape, dtype=np.uint8)
+        flags = flags.copy()
         for i in range(len(vis)):
-            flags[i, ...] = flagger(vis[i, ...]) | \
-                channel_flags[i, :, np.newaxis] | \
-                baseline_flags[i, np.newaxis, :]
+            flags[i, ...] |= flagger(vis[i, ...]) | baseline_flags[i, np.newaxis, :]
         # Apply flags to weights
         if excise:
             weights *= (flags == 0).astype(np.float32) + 2**-64
@@ -651,7 +668,7 @@ class TestIngestOperation:
         return ans
 
     def run_host(
-            self, vis, channel_flags, baseline_flags,
+            self, vis, flags, baseline_flags,
             n_vis, n_sd_vis, n_accs, permutation,
             cont_factor, sd_cont_factor, channel_range, count_flags_channel_range,
             n_sigma, excise, timeseries_weights, percentile_ranges):
@@ -662,9 +679,9 @@ class TestIngestOperation:
         Parameters
         ----------
         vis : array-like
-            Input dump visibilities (first axis being time)
-        channel_flags : array-like
-            Input per-channel flags (indexed by time and channel)
+            Input dump visibilities (indexed by time, channel, baseline)
+        flags : array-like
+            Input per-visibility flags (indexed by time, channel, post-permutation baseline)
         baseline_flags : array-like
             Input per-baseline flags (indexed by time and post-permutation baseline)
         n_vis : int
@@ -702,11 +719,11 @@ class TestIngestOperation:
             - percentileN (where N is a non-negative integer)
         """
         expected = self.run_host_basic(
-            vis[:n_vis], channel_flags[:n_vis], baseline_flags[:n_vis],
+            vis[:n_vis], flags[:n_vis], baseline_flags[:n_vis],
             n_accs, permutation,
             cont_factor, channel_range, None, n_sigma, excise)
         sd_expected = self.run_host_basic(
-            vis[:n_sd_vis], channel_flags[:n_sd_vis], baseline_flags[:n_sd_vis],
+            vis[:n_sd_vis], flags[:n_sd_vis], baseline_flags[:n_sd_vis],
             n_accs, permutation,
             sd_cont_factor, channel_range, count_flags_channel_range, n_sigma, excise)
         for (name, value) in sd_expected.items():
@@ -771,7 +788,7 @@ class TestIngestOperation:
         permutation[permutation >= baselines] = -1
         timeseries_weights = rs.random_integers(0, 1, kept_channels).astype(np.float32)
         timeseries_weights /= np.sum(timeseries_weights)
-        channel_flags = random_flags(rs, (dumps, channels), 2, p=0.05)
+        flags_in = random_flags(rs, (dumps, channels, baselines), 2, p=0.05)
         baseline_flags = random_flags(rs, (dumps, baselines), 2, p=0.05)
 
         flagger_template = self._make_flagger_template(context)
@@ -803,7 +820,7 @@ class TestIngestOperation:
         fn.start_sd_sum()
         for i in range(max(dumps, sd_dumps)):
             fn.buffer('vis_in').set(queue, vis_in[i])
-            fn.buffer('channel_flags').set(queue, channel_flags[i])
+            fn.buffer('flags_in').set(queue, flags_in[i])
             fn.buffer('baseline_flags').set(queue, baseline_flags[i])
             fn()
             if i + 1 == dumps:
@@ -816,7 +833,7 @@ class TestIngestOperation:
                     actual[name] = fn.buffer(name).get(queue)
 
         expected = self.run_host(
-            vis_in, channel_flags, baseline_flags,
+            vis_in, flags_in, baseline_flags,
             dumps, sd_dumps, n_accs, permutation,
             cont_factor, sd_cont_factor, channel_range, count_flags_channel_range,
             n_sigma, excise, timeseries_weights, percentile_ranges)
@@ -868,7 +885,7 @@ class TestIngestOperation:
         fn.start_sd_sum()
         for i in range(dumps):
             fn.buffer('vis_in').zero(queue)
-            fn.buffer('channel_flags').zero(queue)
+            fn.buffer('flags_in').zero(queue)
             fn.buffer('baseline_flags').zero(queue)
             fn()
         fn.end_sum()


### PR DESCRIPTION
This replaces the per-channel flags, and allows for things like channel
masks that vary depending on baseline length (although that is not
currently implemented). A separate baseline mask is still provided:
it is *not* fed into the flagger, because it may still be useful to
provide RFI flagging for a baseline which is suspected to have a faulty
input.

An extra operation (MergeFlags) is added after the flagger to combine
the input flags, baseline flags and RFI flags into a single flag array.
This simplifies the operation of CountFlags and Accum, which no longer
need to do that merging themselves.