### PR TITLE
Support multiple channel masks selected by baseline length

### DIFF
--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -34,6 +34,22 @@ def convert_bitmask(value: str) -> np.ndarray:
         return np.array([c == '1' for c in value])
 
 
+def convert_channel_mask(value: str) -> np.ndarray:
+    """Converts the channel-mask sensor to a numpy array.
+
+    This sensor has two possible formats:
+    - old: single string of 0's and 1's
+    - new: JSON array of strings, each consistenting of 0's and 1's
+    """
+    if not isinstance(value, str):
+        return None
+    elif value[0] in ['0', '1']:
+        return convert_bitmask(value)[np.newaxis, :]
+    else:
+        values = json.loads(value)
+        return np.array([[c == '1' for c in row] for row in values])
+
+
 class Template(string.Template):
     """Template for a sensor name."""
 
@@ -221,7 +237,11 @@ SENSORS = [
     Sensor('${subarray}_sub_nr', immutable=True),
     Sensor('${subarray}_dump_rate', immutable=True),
     Sensor('${subarray}_pool_resources', immutable=True),
-    Sensor('${sub_stream.cbf.antenna_channelised_voltage}_channel_mask', convert=convert_bitmask),
+    Sensor('${sub_stream.cbf.antenna_channelised_voltage}_channel_mask',
+           convert=convert_channel_mask),
+    # TODO: remove ignore_missing once CAM implements this
+    Sensor('${sub_stream.cbf.antenna_channelised_voltage}_channel_mask_max_baseline_lengths',
+           convert=json.loads, immutable=True, ignore_missing=True),
     Sensor('${sub_stream.cbf.antenna_channelised_voltage}_input_data_suspect',
            convert=convert_bitmask),
     Sensor('${sub_stream.cbf.baseline_correlation_products}_channel_data_suspect',

--- a/katsdpcam2telstate/scripts/cam2telstate.py
+++ b/katsdpcam2telstate/scripts/cam2telstate.py
@@ -26,7 +26,7 @@ def comma_split(value: str) -> List[str]:
     return value.split(',')
 
 
-def convert_bitmask(value: str) -> np.ndarray:
+def convert_bitmask(value: object) -> np.ndarray:
     """Converts a string of 1's and 0's to a numpy array of bools"""
     if not isinstance(value, str) or not re.match('^[01]*$', value):
         return None
@@ -34,7 +34,7 @@ def convert_bitmask(value: str) -> np.ndarray:
         return np.array([c == '1' for c in value])
 
 
-def convert_channel_mask(value: str) -> np.ndarray:
+def convert_channel_mask(value: object) -> np.ndarray:
     """Converts the channel-mask sensor to a numpy array.
 
     This sensor has two possible formats:

--- a/katsdpingest/setup.py
+++ b/katsdpingest/setup.py
@@ -25,6 +25,7 @@ setup(
         'katsdpsigproc',
         'katsdpservices[argparse,aiomonitor]',
         'katsdptelstate',
+        'katpoint',
         'katdal'
     ],
     extras_require={


### PR DESCRIPTION
See the blue text at
https://docs.google.com/document/d/1IwA3oWsin5AYjj9Ok8XiYHz21MximMaIxDC9MkfeYJ4/edit#heading=h.sk8r3fbnyn29
for a description of the interface.

It will still need some testing to verify that the CPU can do the
calculation of the per-visibility flags fast enough - if not, that'll
have to be moved to the GPU.

See SPR1-187.