### PR TITLE
Install katportalclient from PyPI not github

### DIFF
--- a/katsdpcam2telstate/requirements.txt
+++ b/katsdpcam2telstate/requirements.txt
@@ -12,10 +12,10 @@ msgpack                      # via katsdptelstate
 netifaces                    # via katsdpservices
 numpy
 pygelf                       # via katsdpservices
-omnijson==0.1.2              # via katportalclient
+omnijson                     # via katportalclient
 redis                        # via katsdptelstate
 terminaltables               # via aiomonitor
 tornado==6.0.2
-ujson==1.35                  # via katportalclient
+ujson                        # via katportalclient
 katsdpservices @ git+ssh://git@github.com/ska-sa/katsdpservices
 katsdptelstate @ git+ssh://git@github.com/ska-sa/katsdptelstate


### PR DESCRIPTION
Per email from Toufeeq, PyPI is now the preferred installation method.