### PR TITLE
Move flag preparation to the GPU

### DIFF
--- a/katsdpingest/katsdpingest/ingest_kernels/prepare_flags.mako
+++ b/katsdpingest/katsdpingest/ingest_kernels/prepare_flags.mako
@@ -1,0 +1,33 @@
+<%include file="/port.mako"/>
+<%namespace name="transpose" file="/transpose_base.mako"/>
+
+<%transpose:transpose_data_class class_name="transpose_flags" type="uchar" block="${block}" vtx="${vtx}" vty="${vty}"/>
+<%transpose:transpose_coords_class class_name="transpose_coords" block="${block}" vtx="${vtx}" vty="${vty}"/>
+
+KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
+    GLOBAL uchar * RESTRICT flags,
+    const GLOBAL uchar * RESTRICT channel_mask,
+    const GLOBAL uint * RESTRICT channel_mask_idx,
+    int flags_stride,
+    int channel_mask_stride,
+    uint max_mask)
+{
+    LOCAL_DECL transpose_flags local_flags;
+    transpose_coords coords;
+    transpose_coords_init_simple(&coords);
+
+    // Compute flags into shared memory
+    <%transpose:transpose_load coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
+        int idx = min(max_mask, channel_mask_idx[${r}]);
+        local_flags.arr[${lr}][${lc}] = channel_mask[idx * channel_mask_stride + ${c}];
+    </%transpose:transpose_load>
+
+    BARRIER();
+
+    // Write flags back to global memory in channel-major order
+    <%transpose:transpose_store coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
+        int addr = ${r} * flags_stride + ${c};
+        flags[addr] = local_flags.arr[${lr}][${lc}];
+    </%transpose:transpose_store>
+}
+

--- a/katsdpingest/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/katsdpingest/test/test_ingest_server.py
@@ -344,7 +344,6 @@ class TestIngestDeviceServer(asynctest.TestCase):
                 flags[:, :, i] |= channel_mask[1] * STATIC_FLAG
             else:
                 # Short baseline
-                print(flags.shape, channel_mask.shape)
                 flags[:, :, i] |= channel_mask[0] * STATIC_FLAG
         return vis, flags, timestamps
 

--- a/katsdpingest/katsdpingest/test/test_ingest_session.py
+++ b/katsdpingest/katsdpingest/test/test_ingest_session.py
@@ -163,7 +163,7 @@ class TestCBFIngest:
         """Test that an ingest processor can be created on the device"""
         template = ingest_session.CBFIngest.create_proc_template(context, [4, 12], 4096, True, True)
         template.instantiate(
-            queue, 1024, Range(96, 1024 - 96), Range(96, 1024 - 96), 544, 512,
+            queue, 1024, Range(96, 1024 - 96), Range(96, 1024 - 96), 544, 512, 1,
             8, 16, [(0, 4), (500, 512)],
             threshold_args={'n_sigma': 11.0})
 


### PR DESCRIPTION
Expanding channel_mask and channel_mask_idx into a per-visibility flag
was too slow on the CPU. It's now mostly done on the CPU, although the
channel_mask and channel_data_suspect sensors are now combined into one
array on the CPU to pass to the GPU. This has been performance-tested
with a 32K simulation on site.