### PR TITLE
Use katdal.flags module

### DIFF
--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -9,6 +9,8 @@
 import pkg_resources
 import numpy as np
 from katsdpsigproc import accel, tune, fill, transpose, percentile, maskedsum, reduce
+from katdal.flags import CAL_RFI
+
 from .utils import Range
 
 
@@ -1200,9 +1202,6 @@ class IngestTemplate:
         Perform continuum averaging of L0 data.
     """
 
-    flag_names = ['reserved0', 'static', 'cam', 'data_lost', 'ingest_rfi',
-                  'predicted_rfi', 'cal_rfi', 'reserved7']
-
     def __init__(self, context, flagger, percentile_sizes, excise, continuum):
         self.context = context
         self.prepare = PrepareTemplate(context)
@@ -1217,7 +1216,7 @@ class IngestTemplate:
         # cal RFI detection happens later in the pipeline, it is definitely
         # safe to use (unlike reserved flags, which might have new meanings
         # defined in future).
-        unflagged_bit = 1 << self.flag_names.index('cal_rfi')
+        unflagged_bit = CAL_RFI
         self.accum = AccumTemplate(context, 2, unflagged_bit, excise)
         self.finalise = FinaliseTemplate(context, unflagged_bit, excise, continuum)
         if continuum:

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -20,17 +20,14 @@ import aiokatcp
 import katsdptelstate
 from katsdptelstate.endpoint import Endpoint
 from katsdpsigproc.test.test_accel import device_test
-import katsdpingest.sigproc
+from katdal.flags import CAM, STATIC
+
 from katsdpingest.utils import Range
 from katsdpingest.ingest_server import IngestDeviceServer
 from katsdpingest.ingest_session import ChannelRanges, BaselineOrdering
 from katsdpingest.test.test_ingest_session import fake_cbf_attr
 from katsdpingest.receiver import Frame
 from katsdpingest.sender import Data
-
-
-STATIC_FLAG = np.uint8(1 << katsdpingest.sigproc.IngestTemplate.flag_names.index('static'))
-CAM_FLAG = np.uint8(1 << katsdpingest.sigproc.IngestTemplate.flag_names.index('cam'))
 
 
 class MockReceiver:
@@ -331,20 +328,20 @@ class TestIngestDeviceServer(asynctest.TestCase):
         flags = np.empty(vis.shape, np.uint8)
         channel_mask = self.fake_channel_mask()
         channel_data_suspect = self.fake_channel_data_suspect()[np.newaxis, :, np.newaxis]
-        flags[:] = channel_data_suspect * CAM_FLAG
+        flags[:] = channel_data_suspect * np.uint8(CAM)
         for i, (a, b) in enumerate(bls.sdp_bls_ordering):
             if a.startswith('m091') or b.startswith('m091'):
                 # data suspect sensor is True
-                flags[:, :, i] |= CAM_FLAG
+                flags[:, :, i] |= CAM
             if a == 'm090v' or b == 'm090v':
                 # input_data_suspect is True
-                flags[:, :, i] |= CAM_FLAG
+                flags[:, :, i] |= CAM
             if a.startswith('m093') ^ b.startswith('m093'):
                 # Long baseline
-                flags[:, :, i] |= channel_mask[1] * STATIC_FLAG
+                flags[:, :, i] |= channel_mask[1] * np.uint8(STATIC)
             else:
                 # Short baseline
-                flags[:, :, i] |= channel_mask[0] * STATIC_FLAG
+                flags[:, :, i] |= channel_mask[0] * np.uint8(STATIC)
         return vis, flags, timestamps
 
     def _channel_average(self, vis, factor):

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -8,6 +8,7 @@ from katsdpsigproc import tune
 import katsdpsigproc.rfi.device as rfi
 import katsdpsigproc.rfi.host as rfi_host
 from katsdpsigproc.test.test_accel import device_test, force_autotune
+from katdal.flags import INGEST_RFI, CAL_RFI
 from nose.tools import assert_equal, assert_raises
 
 from katsdpingest import sigproc
@@ -427,8 +428,8 @@ class TestCompressWeights:
 
 
 class TestIngestOperation:
-    flag_value = 1 << sigproc.IngestTemplate.flag_names.index('ingest_rfi')
-    unflagged_bit = 1 << sigproc.IngestTemplate.flag_names.index('cal_rfi')
+    flag_value = INGEST_RFI
+    unflagged_bit = CAL_RFI
 
     @mock.patch('katsdpsigproc.tune.autotuner_impl', new=tune.stub_autotuner)
     @mock.patch('katsdpsigproc.accel.build', spec=True)


### PR DESCRIPTION
This replaces the hard-coded copy of the flag definitions.

See SPR1-185.