### PR TITLE
Apply the CAM flag to visibilities that are zero

### DIFF
--- a/katsdpingest/ingest_kernels/prepare_flags.mako
+++ b/katsdpingest/ingest_kernels/prepare_flags.mako
@@ -6,11 +6,14 @@
 
 KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
     GLOBAL uchar * RESTRICT flags,
+    const GLOBAL float2 * RESTRICT vis,
     const GLOBAL uchar * RESTRICT channel_mask,
     const GLOBAL uint * RESTRICT channel_mask_idx,
     int flags_stride,
+    int vis_stride,
     int channel_mask_stride,
-    uint max_mask)
+    uint max_mask,
+    uchar zero_flag)
 {
     LOCAL_DECL transpose_flags local_flags;
     transpose_coords coords;
@@ -19,7 +22,11 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
     // Compute flags into shared memory
     <%transpose:transpose_load coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
         int idx = min(max_mask, channel_mask_idx[${r}]);
-        local_flags.arr[${lr}][${lc}] = channel_mask[idx * channel_mask_stride + ${c}];
+        uchar f = channel_mask[idx * channel_mask_stride + ${c}];
+        float2 v = vis[${r} * vis_stride + ${c}];
+        if (v.x == 0 && v.y == 0)
+            f |= zero_flag;
+        local_flags.arr[${lr}][${lc}] = f;
     </%transpose:transpose_load>
 
     BARRIER();

--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -9,7 +9,7 @@
 import pkg_resources
 import numpy as np
 from katsdpsigproc import accel, tune, fill, transpose, percentile, maskedsum, reduce
-from katdal.flags import CAL_RFI
+from katdal.flags import CAL_RFI, CAM
 
 from .utils import Range
 
@@ -197,7 +197,9 @@ class PrepareFlagsTemplate:
     """Generate initial per-visibility flags from CAM sensor data.
 
     Given a collection of channel masks and a per-baseline index of which
-    mask to apply, constructs per-visibility static flags.
+    mask to apply, constructs per-visibility static flags. It also flags
+    visibilities which are zero (since this is assumed to always be a sign
+    of a problem in the correlator).
 
     Parameters
     ----------
@@ -246,7 +248,7 @@ class PrepareFlagsTemplate:
             fn = cls(context, {
                 'block': block,
                 'vtx': vtx,
-                'vty': vty}).instantiate(queue, channels, baselines, masks)
+                'vty': vty}).instantiate(queue, channels, baselines, masks, CAM)
             fn.bind(flags=flags, channel_mask=channel_mask, channel_mask_idx=channel_mask_idx)
             return tune.make_measure(queue, fn)
         return tune.autotune(
@@ -255,8 +257,8 @@ class PrepareFlagsTemplate:
             vtx=[1, 2, 3, 4],
             vty=[1, 2, 3, 4])
 
-    def instantiate(self, command_queue, channels, baselines, masks):
-        return PrepareFlags(self, command_queue, channels, baselines, masks)
+    def instantiate(self, command_queue, channels, baselines, masks, zero_flag):
+        return PrepareFlags(self, command_queue, channels, baselines, masks, zero_flag)
 
 
 class PrepareFlags(accel.Operation):
@@ -264,6 +266,8 @@ class PrepareFlags(accel.Operation):
 
     .. rubric:: Slots
 
+    **vis** : baselines × channels, complex64
+        Input visibilities (output from :class:`Prepare`)
     **flags** : channels × baselines, uint8
         Output channels
     **channel_mask** : masks × channels, uint8
@@ -283,22 +287,27 @@ class PrepareFlags(accel.Operation):
         Number of baselines
     masks : int
         Number of masks in **channel_masks**
+    zero_flag : int
+        Flag value to merge in to flags for zero visibilities
     """
-    def __init__(self, template, command_queue, channels, baselines, masks):
+    def __init__(self, template, command_queue, channels, baselines, masks, zero_flag):
         super().__init__(command_queue)
         self.template = template
         self.channels = channels
         self.baselines = baselines
         self.masks = masks
+        self.zero_flag = zero_flag
         tilex = template.block * template.vtx
         tiley = template.block * template.vty
         padded_channels = accel.Dimension(channels, tilex)
         padded_baselines = accel.Dimension(baselines, tiley)
+        self.slots['vis'] = accel.IOSlot((padded_baselines, padded_channels), np.complex64)
         self.slots['flags'] = accel.IOSlot((padded_channels, padded_baselines), np.uint8)
         self.slots['channel_mask'] = accel.IOSlot((masks, padded_channels), np.uint8)
         self.slots['channel_mask_idx'] = accel.IOSlot((padded_baselines,), np.uint32)
 
     def _run(self):
+        vis = self.buffer('vis')
         flags = self.buffer('flags')
         channel_mask = self.buffer('channel_mask')
         channel_mask_idx = self.buffer('channel_mask_idx')
@@ -311,11 +320,14 @@ class PrepareFlags(accel.Operation):
             self.template.kernel,
             [
                 flags.buffer,
+                vis.buffer,
                 channel_mask.buffer,
                 channel_mask_idx.buffer,
                 np.int32(flags.padded_shape[1]),
+                np.int32(vis.padded_shape[1]),
                 np.int32(channel_mask.padded_shape[1]),
-                np.uint32(self.masks - 1)
+                np.uint32(self.masks - 1),
+                np.uint8(self.zero_flag)
             ],
             global_size=(xblocks * block, yblocks * block),
             local_size=(block, block))
@@ -324,7 +336,8 @@ class PrepareFlags(accel.Operation):
         return {
             'channels': self.channels,
             'baselines': self.baselines,
-            'masks': self.masks
+            'masks': self.masks,
+            'zero_flag': self.zero_flag
         }
 
 
@@ -1367,7 +1380,7 @@ class IngestOperation(accel.OperationSequence):
         self.prepare = template.prepare.instantiate(
             command_queue, channels, cbf_baselines, baselines)
         self.prepare_flags = template.prepare_flags.instantiate(
-            command_queue, channels, baselines, masks)
+            command_queue, channels, baselines, masks, CAM)
         self.init_weights = template.init_weights.instantiate(
             command_queue, (baselines, kept_channels))
         self.zero_spec = Zero(command_queue, kept_channels, baselines)
@@ -1462,7 +1475,8 @@ class IngestOperation(accel.OperationSequence):
                                'merge_flags:flags_in'],
             'baseline_flags': ['merge_flags:baseline_flags'],
             'permutation':    ['prepare:permutation'],
-            'vis_t':          ['prepare:vis_out', 'transpose_vis:src', 'accum:vis_in'],
+            'vis_t':          ['prepare:vis_out', 'transpose_vis:src', 'accum:vis_in',
+                               'prepare_flags:vis'],
             'weights':        ['init_weights:data', 'accum:weights_in'],
             'vis_mid':        ['transpose_vis:dest', 'flagger:vis'],
             'deviations':     ['flagger:deviations'],

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -99,7 +99,7 @@ class TestPrepareFlags:
         rs = np.random.RandomState(seed=1)
         vis = random_vis(rs, (baselines, channels))
         # Create some zero visibilities to ensure they're flagged
-        vis[rs.random((baselines, channels)) < 0.3] = 0
+        vis[rs.rand(baselines, channels) < 0.3] = 0
         channel_mask = random_flags(rs, (masks, channels), 7, 0.1)
         channel_mask_idx = rs.randint(0, masks, baselines).astype(np.uint32)
 

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -8,7 +8,7 @@ from katsdpsigproc import tune
 import katsdpsigproc.rfi.device as rfi
 import katsdpsigproc.rfi.host as rfi_host
 from katsdpsigproc.test.test_accel import device_test, force_autotune
-from katdal.flags import INGEST_RFI, CAL_RFI
+from katdal.flags import INGEST_RFI, CAL_RFI, CAM
 from nose.tools import assert_equal, assert_raises
 
 from katsdpingest import sigproc
@@ -97,18 +97,23 @@ class TestPrepareFlags:
         baselines = 497
         masks = 17
         rs = np.random.RandomState(seed=1)
-        channel_mask = random_flags(rs, (masks, channels), 8, 0.1)
+        vis = random_vis(rs, (baselines, channels))
+        # Create some zero visibilities to ensure they're flagged
+        vis[rs.random((baselines, channels)) < 0.3] = 0
+        channel_mask = random_flags(rs, (masks, channels), 7, 0.1)
         channel_mask_idx = rs.randint(0, masks, baselines).astype(np.uint32)
 
         template = sigproc.PrepareFlagsTemplate(context)
-        fn = template.instantiate(queue, channels, baselines, masks)
+        fn = template.instantiate(queue, channels, baselines, masks, 2**7)
         fn.ensure_all_bound()
+        fn.buffer('vis').set(queue, vis)
         fn.buffer('channel_mask').set(queue, channel_mask)
         fn.buffer('channel_mask_idx').set(queue, channel_mask_idx)
         fn()
         flags = fn.buffer('flags').get(queue)
 
         expected = channel_mask[channel_mask_idx, :].T
+        expected = expected | np.where(vis.T == 0, 2**7, 0)
         np.testing.assert_equal(expected, flags)
 
 
@@ -467,7 +472,7 @@ class TestIngestOperation:
             ('ingest:prepare_flags', {
                 'baselines': 192, 'channels': 128,
                 'class': 'katsdpingest.sigproc.PrepareFlags',
-                'masks': 3
+                'masks': 3, 'zero_flag': CAM
             }),
             ('ingest:init_weights', {
                 'class': 'katsdpsigproc.fill.Fill', 'shape': (192, 80),
@@ -940,6 +945,6 @@ class TestIngestOperation:
         cont_vis = fn.buffer('cont_vis').get(queue)
         cont_flags = fn.buffer('cont_flags').get(queue)
         np.testing.assert_equal(0 + 0j, spec_vis)
-        np.testing.assert_equal(0, spec_flags)
+        np.testing.assert_equal(CAM, spec_flags)
         np.testing.assert_equal(0 + 0j, cont_vis)
-        np.testing.assert_equal(0, cont_flags)
+        np.testing.assert_equal(CAM, cont_flags)

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -97,9 +97,9 @@ class TestPrepareFlags:
         baselines = 497
         masks = 17
         rs = np.random.RandomState(seed=1)
-        vis = random_vis(rs, (baselines, channels))
+        vis = random_vis(rs, (channels, baselines))
         # Create some zero visibilities to ensure they're flagged
-        vis[rs.rand(baselines, channels) < 0.3] = 0
+        vis[rs.rand(channels, baselines) < 0.3] = 0
         channel_mask = random_flags(rs, (masks, channels), 7, 0.1)
         channel_mask_idx = rs.randint(0, masks, baselines).astype(np.uint32)
 
@@ -113,7 +113,7 @@ class TestPrepareFlags:
         flags = fn.buffer('flags').get(queue)
 
         expected = channel_mask[channel_mask_idx, :].T
-        expected = expected | np.where(vis.T == 0, 2**7, 0)
+        expected = expected | np.where(vis == 0, 2**7, 0)
         np.testing.assert_equal(expected, flags)
 
 


### PR DESCRIPTION
CBF fills in zeros for lost or otherwise unusable data, and the
sensor-provided CAM flags are insufficient to flag all such cases.