### PR TITLE
Use RFI mask from model

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ katsdp.setDependencies([
     'ska-sa/katsdpdockerbase/master',
     'ska-sa/katsdpservices/master',
     'ska-sa/katsdptelstate/master',
+    'ska-sa/katsdpmodels/master',
     'ska-sa/katdal'])
 
 catchError {

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -25,7 +25,7 @@ import katsdpsigproc.accel
 from katsdpsigproc import resource
 import katsdpsigproc.rfi.device as rfi
 
-import katsdpmodels.fetch
+import katsdpmodels.fetch.requests
 import katsdpmodels.rfi_mask
 
 import katsdpservices
@@ -631,8 +631,8 @@ class CBFIngest:
             return
         try:
             rfi_mask_url = urllib.parse.urljoin(base_url, rfi_mask_rel_url)
-            self._rfi_mask_model = katsdpmodels.fetch.fetch_model(rfi_mask_url,
-                                                                  katsdpmodels.rfi_mask.RFIMask)
+            self._rfi_mask_model = katsdpmodels.fetch.requests.fetch_model(
+                rfi_mask_url, katsdpmodels.rfi_mask.RFIMask)
         except (requests.exceptions.RequestException, katsdpmodels.models.ModelError) as exc:
             logger.warning('Failed to load RFI mask model: %s', exc, exc_info=True)
 

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -627,7 +627,7 @@ class CBFIngest:
             rfi_mask_model_key = self.telstate.join('model', 'rfi_mask', 'fixed')
             rfi_mask_rel_url = self.telstate[rfi_mask_model_key]
         except KeyError:
-            logger.info('Telescope state did not specify an RFI model')
+            logger.warning('Telescope state did not specify an RFI model')
             return
         try:
             rfi_mask_url = urllib.parse.urljoin(base_url, rfi_mask_rel_url)

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -624,7 +624,8 @@ class CBFIngest:
         self._rfi_mask_model = None
         try:
             base_url = self.telstate['sdp_model_base_url']
-            rfi_mask_rel_url = self.telstate['rfi_mask_model_fixed']
+            rfi_mask_model_key = self.telstate.join('model', 'rfi_mask', 'fixed')
+            rfi_mask_rel_url = self.telstate[rfi_mask_model_key]
         except KeyError:
             logger.info('Telescope state did not specify an RFI model')
             return

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -12,6 +12,8 @@ import urllib.parse
 from typing import Mapping, Dict, List, Tuple, Set, Iterable, Optional, Any   # noqa: F401
 
 import numpy as np
+import astropy.units as u
+import requests
 
 import spead2
 import spead2.send
@@ -23,7 +25,6 @@ import katsdpsigproc.accel
 from katsdpsigproc import resource
 import katsdpsigproc.rfi.device as rfi
 
-import requests
 import katsdpmodels.fetch
 import katsdpmodels.rfi_mask
 
@@ -538,8 +539,9 @@ class CBFIngest:
     bls_channel_mask_idx : :class:`np.ndarray`, 1D
         Index into list of channel masks for each baseline. The baselines
         correspond to `bls_ordering.sdp_bls_ordering`.
-    n_channel_masks : int
-        Number of channel masks indexed by bls_channel_mask_idx
+    static_masks : :class:`np.ndarray`, 2D
+        Static channel masks. Each row contains one channel mask, and the
+        rows are indexed by the values in bls_channel_mask_idx.
     telstate : :class:`katsdptelstate.TelescopeState`
         Global view of telescope state
     l0_names : list of str
@@ -640,20 +642,35 @@ class CBFIngest:
             raise ValueError('No baselines (bls_ordering = {}, antenna_mask = {})'.format(
                 self.cbf_attr['bls_ordering'], antenna_mask))
 
-        # Determine which channel mask to use for each baseline
-        thresholds = np.array(self.telstate_cbf.get('channel_mask_max_baseline_lengths', []))
-        bls = self.bls_ordering.sdp_bls_ordering
-        antenna_names = set(input_name[:-1] for input_name in bls.flat)
-        antennas = [katpoint.Antenna(self.telstate['{}_observer'.format(name)])
-                    for name in antenna_names]
-        ref = antennas[0].array_reference_antenna()
-        # Turn each antenna into a location East/North/Up of the reference
-        locations = {antenna.name: np.array(ref.baseline_toward(antenna))
-                     for antenna in antennas}
-        lengths = np.array([np.linalg.norm(locations[a[:-1]] - locations[b[:-1]])
-                            for (a, b) in bls])
-        self.bls_channel_mask_idx = np.searchsorted(thresholds, lengths, 'right').astype(np.uint32)
-        self.n_channel_masks = len(thresholds) + 1
+        # Pre-compute channel masks from the RFI model
+        if self._rfi_mask_model is not None:
+            bls = self.bls_ordering.sdp_bls_ordering
+            antenna_names = set(input_name[:-1] for input_name in bls.flat)
+            antennas = [katpoint.Antenna(self.telstate['{}_observer'.format(name)])
+                        for name in antenna_names]
+            ref = antennas[0].array_reference_antenna()
+            # Turn each antenna into a location East/North/Up of the reference
+            locations = {antenna.name: np.array(ref.baseline_toward(antenna))
+                         for antenna in antennas}
+            lengths = np.array([np.linalg.norm(locations[a[:-1]] - locations[b[:-1]])
+                                for (a, b) in bls]) << u.m
+            cbf_spw = SpectralWindow(
+                self.cbf_attr['center_freq'], None, len(self.channel_ranges.cbf),
+                bandwidth=self.cbf_attr['bandwidth'], sideband=1)
+            spw = cbf_spw.subrange(self.channel_ranges.input.start,
+                                   self.channel_ranges.input.stop)
+            freqs = spw.channel_freqs << u.Hz
+            # Get masks as a baseline x freq array
+            masks = self._rfi_mask_model.is_masked(freqs[np.newaxis, :], lengths[:, np.newaxis])
+            # Typically the model will only have a few threshold lengths, so
+            # most rows will be the same. Reduce it to just unique rows, with
+            # a lookup table.
+            masks, indices = np.unique(masks, axis=0, return_inverse=True)
+            self.bls_channel_mask_idx = indices.astype(np.uint32)
+            self.static_masks = masks * np.uint8(STATIC)
+        else:
+            self.bls_channel_mask_idx = np.zeros(len(self.bls_ordering.sdp_bls_ordering), np.uint32)
+            self.static_masks = np.zeros((1, len(self.channel_ranges.input)), np.uint8)
 
     def _init_time_averaging(self, output_int_time: float, sd_int_time: float) -> None:
         output_ratio = max(1, int(round(output_int_time / self.cbf_attr['int_time'])))
@@ -698,7 +715,7 @@ class CBFIngest:
             self.channel_ranges.sd_output.relative_to(self.channel_ranges.input),
             len(self.cbf_attr['bls_ordering']),
             len(self.bls_ordering.sdp_bls_ordering),
-            self.n_channel_masks,
+            self.static_masks.shape[0],
             self.channel_ranges.cont_factor,
             self.channel_ranges.sd_cont_factor,
             self.bls_ordering.percentile_ranges,
@@ -1276,9 +1293,13 @@ class CBFIngest:
 
         channel_mask_sensor = sensor_value(self.telstate_cbf, 'channel_mask')
         if channel_mask_sensor is not None:
-            channel_mask[:] = channel_mask_sensor[:, channel_slice] * static_flag
+            if channel_mask_sensor.ndim == 2:
+                logger.warning('2D channel_mask is no longer supported - update katsdpcam2telstate')
+                channel_mask_sensor = channel_mask_sensor[0, channel_slice]
+            dynamic_masks = channel_mask_sensor[channel_slice] * static_flag
+            channel_mask[:] = self.static_masks | dynamic_masks
         else:
-            channel_mask.fill(0)
+            channel_mask[:] = self.static_masks
 
         if self.use_data_suspect:
             channel_data_suspect = sensor_value(self.telstate_cbf, 'channel_data_suspect')

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -275,7 +275,8 @@ class TestIngestDeviceServer(asynctest.TestCase):
                                       side_effect=self._get_sd_tx)
         self._patch('katsdpservices.get_interface_address',
                     side_effect=lambda interface: '127.0.0.' + interface[-1] if interface else None)
-        self._patch('katsdpmodels.fetch.Fetcher.get', return_value=self.fake_rfi_mask_model())
+        self._patch('katsdpmodels.fetch.requests.Fetcher.get',
+                    return_value=self.fake_rfi_mask_model())
         self._server = IngestDeviceServer(
             user_args, self.channel_ranges, self.cbf_attr, context,
             host=user_args.host, port=user_args.port)

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -21,6 +21,9 @@ import katsdptelstate
 from katsdptelstate.endpoint import Endpoint
 from katsdpsigproc.test.test_accel import device_test
 from katdal.flags import CAM, STATIC
+import katsdpmodels.rfi_mask
+import astropy.table
+import astropy.units as u
 
 from katsdpingest.utils import Range
 from katsdpingest.ingest_server import IngestDeviceServer
@@ -91,6 +94,7 @@ class MockReceiver:
 
 class DeepCopyMock(mock.MagicMock):
     """Mock that takes deep copies of its arguments when called."""
+
     def __call__(self, *args, **kwargs):
         return super().__call__(*copy.deepcopy(args), **copy.deepcopy(kwargs))
 
@@ -117,6 +121,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
     lost data and so on. It is intended to check that the katcp commands
     function and that the correct channels are sent to the correct places.
     """
+
     def _patch(self, *args, **kwargs):
         patcher = mock.patch(*args, **kwargs)
         mock_obj = patcher.start()
@@ -155,14 +160,21 @@ class TestIngestDeviceServer(asynctest.TestCase):
         return data, timestamps
 
     def fake_channel_mask(self):
-        channel_mask = np.zeros((2, self.cbf_attr['n_chans']), np.bool_)
-        channel_mask[0, 464] = True
-        channel_mask[0, 700:800] = True
-        channel_mask[0, 900] = True
-        channel_mask[1, 500] = True
-        channel_mask[1, 200:330] = True
-        channel_mask[1, 900:905] = True
+        channel_mask = np.zeros((self.cbf_attr['n_chans']), np.bool_)
+        channel_mask[704] = True
+        channel_mask[750:800] = True
+        channel_mask[900] = True
         return channel_mask
+
+    def fake_rfi_mask_model(self):
+        # Channels 852:857 and 1024
+        ranges = astropy.table.QTable(
+            [[1034e6, 1070.0e6] * u.Hz,
+             [1035e6, 1070.0e6] * u.Hz,
+             [1500, np.inf] * u.m],
+            names=('min_frequency', 'max_frequency', 'max_baseline')
+        )
+        return katsdpmodels.rfi_mask.RFIMaskRanges(ranges)
 
     def fake_channel_data_suspect(self):
         bad = np.zeros(self.cbf_attr['n_chans'], np.bool_)
@@ -217,10 +229,10 @@ class TestIngestDeviceServer(asynctest.TestCase):
         self._telstate['i0_baseline_correlation_products_src_streams'] = \
             ['i0_antenna_channelised_voltage']
         self._telstate['i0_antenna_channelised_voltage_instrument_dev_name'] = 'i0'
+        self._telstate['sdp_model_base_url'] = 'http://test.invalid/'
+        self._telstate['rfi_mask_model_fixed'] = 'rfi_mask/hash/sha256_deadbeef.hdf5'
         self._telstate.add('i0_antenna_channelised_voltage_channel_mask',
                            self.fake_channel_mask(), ts=0)
-        self._telstate['i0_antenna_channelised_voltage_channel_mask_max_baseline_lengths'] = \
-            [1500.0]
         self._telstate.add('m090_data_suspect', False, ts=0)
         self._telstate.add('m091_data_suspect', True, ts=0)
         input_data_suspect = np.zeros(len(self.cbf_attr['input_labels']), np.bool_)
@@ -262,6 +274,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
                                       side_effect=self._get_sd_tx)
         self._patch('katsdpservices.get_interface_address',
                     side_effect=lambda interface: '127.0.0.' + interface[-1] if interface else None)
+        self._patch('katsdpmodels.fetch.Fetcher.get', return_value=self.fake_rfi_mask_model())
         self._server = IngestDeviceServer(
             user_args, self.channel_ranges, self.cbf_attr, context,
             host=user_args.host, port=user_args.port)
@@ -337,12 +350,11 @@ class TestIngestDeviceServer(asynctest.TestCase):
             if a == 'm090v' or b == 'm090v':
                 # input_data_suspect is True
                 flags[:, :, i] |= CAM
-            if a.startswith('m093') ^ b.startswith('m093'):
-                # Long baseline
-                flags[:, :, i] |= channel_mask[1] * np.uint8(STATIC)
-            else:
+            flags[:, :, i] |= channel_mask * np.uint8(STATIC)
+            flags[:, 1024, i] |= np.uint8(STATIC)   # RFI model
+            if a.startswith('m093') == b.startswith('m093'):
                 # Short baseline
-                flags[:, :, i] |= channel_mask[0] * np.uint8(STATIC)
+                flags[:, 852:857, i] |= np.uint8(STATIC)
         return vis, flags, timestamps
 
     def _channel_average(self, vis, factor):

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -230,7 +230,8 @@ class TestIngestDeviceServer(asynctest.TestCase):
             ['i0_antenna_channelised_voltage']
         self._telstate['i0_antenna_channelised_voltage_instrument_dev_name'] = 'i0'
         self._telstate['sdp_model_base_url'] = 'http://test.invalid/'
-        self._telstate['rfi_mask_model_fixed'] = 'rfi_mask/hash/sha256_deadbeef.hdf5'
+        rfi_mask_model_key = self._telstate.join('model', 'rfi_mask', 'fixed')
+        self._telstate[rfi_mask_model_key] = 'rfi_mask/fixed/sha256_deadbeef.hdf5'
         self._telstate.add('i0_antenna_channelised_voltage_channel_mask',
                            self.fake_channel_mask(), ts=0)
         self._telstate.add('m090_data_suspect', False, ts=0)

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -174,7 +174,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
              [1500, np.inf] * u.m],
             names=('min_frequency', 'max_frequency', 'max_baseline')
         )
-        return katsdpmodels.rfi_mask.RFIMaskRanges(ranges)
+        return katsdpmodels.rfi_mask.RFIMaskRanges(ranges, False)
 
     def fake_channel_data_suspect(self):
         bad = np.zeros(self.cbf_attr['n_chans'], np.bool_)
@@ -353,10 +353,12 @@ class TestIngestDeviceServer(asynctest.TestCase):
                 # input_data_suspect is True
                 flags[:, :, i] |= CAM
             flags[:, :, i] |= channel_mask * np.uint8(STATIC)
-            flags[:, 1024, i] |= np.uint8(STATIC)   # RFI model
-            if a.startswith('m093') == b.startswith('m093'):
-                # Short baseline
-                flags[:, 852:857, i] |= np.uint8(STATIC)
+            if a[:-1] != b[:-1]:
+                # RFI model, which doesn't apply to auto-correlations
+                flags[:, 1024, i] |= np.uint8(STATIC)
+                if a.startswith('m093') == b.startswith('m093'):
+                    # Short baseline
+                    flags[:, 852:857, i] |= np.uint8(STATIC)
         return vis, flags, timestamps
 
     def _channel_average(self, vis, factor):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aioconsole                # via aiomonitor
 aiokatcp
 aiomonitor
 appdirs                   # via katsdpsigproc
+astropy                   # via katsdpmodels
 async-timeout             # via aiokatcp
 certifi                   # via requests
 chardet                   # via requests
@@ -10,7 +11,7 @@ dask                      # via katdal
 decorator                 # via katsdpsigproc
 ephem                     # via pyephem
 future                    # via katdal
-h5py                      # via katdal
+h5py                      # via katdal, katsdpmodels
 hiredis                   # via katsdptelstate
 idna                      # via requests
 katversion
@@ -30,18 +31,21 @@ python-dateutil           # via pandas
 pytools                   # via pycuda
 pytz                      # via pandas
 redis                     # via katsdptelstate
-requests                  # via katdal
+requests                  # via katdal, katsdpmodels
+requests_file==1.5.1      # via katsdpmodels
 scipy                     # via katsdpsigproc
 six                       # via spead2 (and probably others)
 spead2
+strict_rfc3339==0.7       # via katsdpmodels
 terminaltables            # via aiomonitor
-typing_extensions         # via katsdpsigproc
+typing_extensions         # via katsdpsigproc, katsdpmodels
 toolz                     # via dask
 urllib3                   # via requests
 # TODO: eventually switch to using a release of katdal, once the enhanced
 # SpectralWindow class has shipped.
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
+katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels
 katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ urllib3                   # via requests
 # SpectralWindow class has shipped.
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
-katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels@first-version
+katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels
 katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ urllib3                   # via requests
 # SpectralWindow class has shipped.
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
-katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels
+katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels@first-version
 katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,11 +32,10 @@ pytools                   # via pycuda
 pytz                      # via pandas
 redis                     # via katsdptelstate
 requests                  # via katdal, katsdpmodels
-requests_file==1.5.1      # via katsdpmodels
 scipy                     # via katsdpsigproc
 six                       # via spead2 (and probably others)
 spead2
-strict_rfc3339==0.7       # via katsdpmodels
+strict-rfc3339            # via katsdpmodels
 terminaltables            # via aiomonitor
 typing_extensions         # via katsdpsigproc, katsdpmodels
 toolz                     # via dask

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     install_requires=[
         'aiokatcp>=0.7.0',   # Need 0.7 for auto_strategy
         'aiomonitor',
-        'numpy',
-        'spead2>=1.8.0',   # Needed for inproc transport for unit tests
+        'numpy>=1.13.0',     # For np.unique with axis (might really need a higher version)
+        'spead2>=1.8.0',     # Needed for inproc transport for unit tests
         'katsdpsigproc',
         'katsdpservices[argparse,aiomonitor]',
         'katsdptelstate',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'katsdpservices[argparse,aiomonitor]',
         'katsdptelstate',
         'katpoint',
-        'katdal'
+        'katdal',
+        'katsdpmodels'
     ],
     extras_require={
         'test': tests_require

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'katsdptelstate',
         'katpoint',
         'katdal',
-        'katsdpmodels'
+        'katsdpmodels[requests]'
     ],
     extras_require={
         'test': tests_require


### PR DESCRIPTION
To avoid things getting overly complicated, I've removed support for baseline-dependent RFI masks from CAM. @ajoubertza has confirmed that CAM haven't implemented it, and trying to merge them with the RFI mask model would have made the already somewhat complicated code slightly hairy.

The unit tests have slightly more rework than might be expected, because I discovered that some of the testing was done by fiddling with data outside of the channel range being processed by the system-under-test and hence was useless.

This should continue to work without an RFI mask available, but it will print a warning about the CAM-supplied mask being 2D because cam2telstate currently converts the CAM sensor into a 2D array in anticipation of baseline-dependent masks. Once this is deployed merged I can update cam2telstate to strip out support for the baseline-dependent channel masks.

Depends on ska-sa/katsdpmodels#7, so will probably fail unit tests at the moment.