### PR TITLE
Add sensor for time spent in telstate

### DIFF
--- a/katsdpingest/ingest_server.py
+++ b/katsdpingest/ingest_server.py
@@ -124,6 +124,9 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
                     "Number of spectral visibilities computed for signal displays in this session"),
             counter("output-flagged-total",
                     "Number of flagged visibilities (out of output-vis-total)"),
+            Sensor(float, "telstate-seconds-total",
+                   "Time spent waiting for telescope state queries (prometheus: counter)", "s",
+                   initial_status=Sensor.Status.NOMINAL),
             Sensor(bool, "descriptors-received",
                    "Whether the SPEAD descriptors have been received "
                    " (prometheus: gauge)",


### PR DESCRIPTION
It counts time fetching sensors during the capture process, so that if
we start dropping data again we can tell whether it was caused by a slow
telstate.