### PR TITLE
Use asyncio telstate

### DIFF
--- a/katsdpingest/ingest_server.py
+++ b/katsdpingest/ingest_server.py
@@ -11,7 +11,7 @@ import katsdptelstate.aio
 from katsdptelstate.endpoint import endpoint_parser
 
 import katsdpingest
-from .ingest_session import CBFIngest, Status, DeviceStatus, ChannelRanges
+from .ingest_session import CBFIngest, Status, DeviceStatus, ChannelRanges, SystemAttrs
 from . import receiver
 from .utils import Sensor
 
@@ -42,13 +42,14 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
     ----------
     user_args : :class:`argparse.Namespace`
         Command-line arguments
-    telstate : :class:`katsdptelstate.aio.TelescopeState`
-        Asynchronous client for the telescope state
+    telstate_cbf : :class:`katsdptelstate.aio.TelescopeState`
+        Asynchronous client for the telescope state, as returned by
+        :func:`katsdpingest.utils.cbf_telstate_view`.
     channel_ranges : :class:`katsdpingest.ingest_session.ChannelRanges`
         Ranges of channels for various parts of the pipeline
-    cbf_attr : dict
-        CBF stream configuration, as returned by
-        :func:`katsdpingest.ingest_session.get_cbf_attr`.
+    system_attrs : :class:`katsdpingest.ingest_session.SystemAttrs`
+        System configuration, as returned by
+        :meth:`katsdpingest.ingest_session.SystemAttrs.create`.
     context : :class:`katsdpsigproc.cuda.Context` or :class:`katsdpsigproc.opencl.Context`
         Context in which to compile device code and allocate resources
     args, kwargs
@@ -61,9 +62,9 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
     def __init__(
             self,
             user_args: argparse.Namespace,
-            telstate: katsdptelstate.aio.TelescopeState,
+            telstate_cbf: katsdptelstate.aio.TelescopeState,
             channel_ranges: ChannelRanges,
-            cbf_attr: Dict[str, Any],
+            system_attrs: SystemAttrs,
             context, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._stopping = False
@@ -146,11 +147,15 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
 
         # create the device resources
         self.cbf_ingest = CBFIngest(
-            user_args, cbf_attr, channel_ranges, context,
-            cast(Mapping[str, Sensor], self.sensors), telstate)
+            user_args, system_attrs, channel_ranges, context,
+            cast(Mapping[str, Sensor], self.sensors), telstate_cbf)
         # add default or user specified endpoints
         for sdisp_endpoint in user_args.sdisp_spead:
             self.cbf_ingest.add_sdisp_ip(sdisp_endpoint)
+
+    async def start(self) -> None:
+        await self.cbf_ingest.populate_telstate()
+        await super().start()
 
     async def request_enable_debug(self, ctx) -> str:
         """Enable debugging of the ingest process."""

--- a/katsdpingest/ingest_server.py
+++ b/katsdpingest/ingest_server.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Mapping, Any, cast   # noqa: F401
 
 import aiokatcp
 from aiokatcp import FailReply, SensorSampler
+import katsdptelstate.aio
 from katsdptelstate.endpoint import endpoint_parser
 
 import katsdpingest
@@ -41,6 +42,8 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
     ----------
     user_args : :class:`argparse.Namespace`
         Command-line arguments
+    telstate : :class:`katsdptelstate.aio.TelescopeState`
+        Asynchronous client for the telescope state
     channel_ranges : :class:`katsdpingest.ingest_session.ChannelRanges`
         Ranges of channels for various parts of the pipeline
     cbf_attr : dict
@@ -58,6 +61,7 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
     def __init__(
             self,
             user_args: argparse.Namespace,
+            telstate: katsdptelstate.aio.TelescopeState,
             channel_ranges: ChannelRanges,
             cbf_attr: Dict[str, Any],
             context, *args, **kwargs) -> None:
@@ -143,7 +147,7 @@ class IngestDeviceServer(aiokatcp.DeviceServer):
         # create the device resources
         self.cbf_ingest = CBFIngest(
             user_args, cbf_attr, channel_ranges, context,
-            cast(Mapping[str, Sensor], self.sensors), user_args.telstate)
+            cast(Mapping[str, Sensor], self.sensors), telstate)
         # add default or user specified endpoints
         for sdisp_endpoint in user_args.sdisp_spead:
             self.cbf_ingest.add_sdisp_ip(sdisp_endpoint)

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -15,7 +15,7 @@ from typing import (
 
 import numpy as np
 import astropy.units as u
-import requests
+import aiohttp
 
 import spead2
 import spead2.send
@@ -486,7 +486,7 @@ class SystemAttrs:
                                                katsdpmodels.rfi_mask.RFIMask)
             logger.info('Loaded rfi_mask model')
             return rfi_mask_model
-        except (requests.exceptions.RequestException, katsdpmodels.models.ModelError) as exc:
+        except (aiohttp.ClientError, katsdpmodels.models.ModelError) as exc:
             logger.warning('Failed to load rfi_mask model: %s', exc, exc_info=True)
             return None
 
@@ -501,7 +501,7 @@ class SystemAttrs:
                                                 telstate=telstate_cbf)
             logger.info('Loaded band_mask model')
             return band_mask_model
-        except (requests.exceptions.RequestException, katsdpmodels.models.ModelError) as exc:
+        except (aiohttp.ClientError, katsdpmodels.models.ModelError) as exc:
             logger.warning('Failed to load band_mask model: %s', exc, exc_info=True)
             return None
 

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -10,7 +10,7 @@ import argparse
 import textwrap
 import gc
 from typing import (
-    Mapping, Dict, List, Tuple, Set, Iterable, Optional, TypeVar, Any
+    Mapping, Dict, List, Tuple, Set, Iterable, Callable, Awaitable, Optional, TypeVar, Any
 )    # noqa: F401
 
 import numpy as np
@@ -36,8 +36,8 @@ import katsdpservices
 from katdal import SpectralWindow
 from katdal.flags import CAM, DATA_LOST, INGEST_RFI, STATIC
 import katpoint
-import katsdptelstate
-from katsdptelstate.endpoint import endpoints_to_str
+import katsdptelstate.aio
+from katsdptelstate.endpoint import endpoints_to_str, Endpoint
 
 from . import utils, receiver, sender, sigproc
 from .utils import Sensor
@@ -73,12 +73,15 @@ class _TimeAverage:
 
     This object never sees dump contents directly, only dump indices. When an
     index is added that is not part of the current group, :func:`flush`
-    is called, which must be overloaded or set to a callback function.
+    is called, which must be set to a callback function.
 
     Parameters
     ----------
     ratio : int
         Number of input dumps per output dump
+    flush
+        Asynchronous callback which is called once a set of dumps is ready to
+        be averaged. It is passed the output dump index.
 
     Attributes
     ----------
@@ -89,31 +92,29 @@ class _TimeAverage:
         There is at least one dump in the current group if and only if this is
         not ``None``.
     """
-    def __init__(self, ratio: int) -> None:
+    def __init__(self, ratio: int, flush: Callable[[int], Awaitable[None]]) -> None:
         self.ratio = ratio
-        self._start_idx = None    # type: Optional[int]
+        self.flush = flush
+        self._start_idx: Optional[int] = None
 
     def _warp_start(self, idx: int) -> None:
         """Set :attr:`start_idx` to the smallest multiple of ratio that is <= idx."""
         self._start_idx = idx // self.ratio * self.ratio
 
-    def add_index(self, idx: int) -> None:
+    async def add_index(self, idx: int) -> None:
         """Record that a dump with a given index has arrived and is about to
         be processed. This may call :func:`flush`."""
 
         if self._start_idx is None:
             self._warp_start(idx)
         elif idx >= self._start_idx + self.ratio:
-            self.flush(self._start_idx // self.ratio)
+            await self.flush(self._start_idx // self.ratio)
             self._warp_start(idx)
 
-    def flush(self, out_idx: int) -> None:
-        raise NotImplementedError
-
-    def finish(self, flush: bool = True) -> None:
+    async def finish(self, flush: bool = True) -> None:
         """Flush if not empty and `flush` is true, and reset to initial state"""
         if self._start_idx is not None and flush:
-            self.flush(self._start_idx // self.ratio)
+            await self.flush(self._start_idx // self.ratio)
         self._start_idx = None
 
 
@@ -336,7 +337,7 @@ class _ResourceSet:
             raise ValueError('_ResourceSet needs at least one buffer')
         buffers = {name: proc.buffer(name) for name in names}
         self._device = resource.Resource(buffers)
-        self._host = []    # type: List[resource.Resource]
+        self._host: List[resource.Resource] = []
         for i in range(N):
             host = {name: buffer.empty_like() for name, buffer in buffers.items()}
             self._host.append(resource.Resource(host))
@@ -449,7 +450,7 @@ class BaselineOrdering:
             return [auto, autohh, autovv, autohv, cross, crosshh, crossvv, crosshv]
 
         if antenna_mask is not None:
-            antenna_mask_set = set(antenna_mask)   # type: Optional[Set[str]]
+            antenna_mask_set: Optional[Set[str]] = set(antenna_mask)
         else:
             antenna_mask_set = None
         # Eliminate baselines not covered by antenna_mask_set
@@ -467,7 +468,7 @@ class BaselineOrdering:
 
         # Collect percentile ranges
         collection_products = get_collection_products(self.sdp_bls_ordering)
-        self.percentile_ranges = []   # type: List[Tuple[int, int]]
+        self.percentile_ranges: List[Tuple[int, int]] = []
         for p in collection_products:
             if p:
                 start = p[0]
@@ -488,28 +489,28 @@ class TelstateReceiver(receiver.Receiver):
 
     Parameters
     ----------
-    telstates : list of :class:`katsdptelstate.TelescopeState`
+    telstates : list of :class:`katsdptelstate.aio.TelescopeState`
         Telescope state views with scopes unique to the capture session (but shared
         across cooperating ingest servers).
     l0_int_time : float
         Output integration time
     """
     def __init__(self, *args, **kwargs) -> None:
-        self._telstates = kwargs.pop('telstates')
-        self._l0_int_time = kwargs.pop('l0_int_time')
+        self._telstates: List[katsdptelstate.aio.TelescopeState] = kwargs.pop('telstates')
+        self._l0_int_time: float = kwargs.pop('l0_int_time')
         super().__init__(*args, **kwargs)
 
-    def _first_timestamp(self, candidate: int) -> int:
+    async def _first_timestamp(self, candidate: int) -> int:
         scaled = candidate / self.cbf_attr['scale_factor_timestamp'] + 0.5 * self._l0_int_time
         try:
             for telstate in self._telstates:
-                telstate['first_timestamp_adc'] = candidate
-                telstate['first_timestamp'] = scaled
+                await telstate.set('first_timestamp_adc', candidate)
+                await telstate.set('first_timestamp', scaled)
             return candidate
         except katsdptelstate.ImmutableKeyError:
             # A different ingest process beat us to it. Use its value.
             # That other process will fill in the remaining values
-            return self._telstates[0].get('first_timestamp_adc')
+            return await self._telstates[0].get('first_timestamp_adc')
 
 
 class CBFIngest:
@@ -546,7 +547,7 @@ class CBFIngest:
     static_masks : :class:`np.ndarray`, 2D
         Static channel masks. Each row contains one channel mask, and the
         rows are indexed by the values in bls_channel_mask_idx.
-    telstate : :class:`katsdptelstate.TelescopeState`
+    telstate : :class:`katsdptelstate.aio.TelescopeState`
         Global view of telescope state
     l0_names : list of str
         Stream names of the L0 stream, for those streams being transmitted
@@ -624,7 +625,12 @@ class CBFIngest:
         self.output_flagged_sensor.set_value(0, timestamp=now)
         self.output_vis_sensor.set_value(0, timestamp=now)
 
-    def _init_baselines(self, antenna_mask: Iterable[str]) -> None:
+    def _init_baselines(self, telstate: katsdptelstate.TelescopeState,
+                        antenna_mask: Iterable[str]) -> None:
+        # Transfer prefixes from async self.telstate_cbf to synchronous telstate.
+        telstate_cbf = katsdptelstate.TelescopeState(
+            telstate.backend, prefixes=self.telstate_cbf.prefixes
+        )
         # Configure the masking and reordering of baselines
         self.bls_ordering = BaselineOrdering(self.cbf_attr['bls_ordering'], antenna_mask)
         if not len(self.bls_ordering.sdp_bls_ordering):
@@ -632,7 +638,7 @@ class CBFIngest:
                 self.cbf_attr['bls_ordering'], antenna_mask))
 
         # Pre-compute channel masks from the RFI mask and band mask models
-        with katsdpmodels.fetch.requests.TelescopeStateFetcher(self.telstate) as fetcher:
+        with katsdpmodels.fetch.requests.TelescopeStateFetcher(telstate) as fetcher:
             cbf_spw = SpectralWindow(
                 self.cbf_attr['center_freq'], None, len(self.channel_ranges.cbf),
                 bandwidth=self.cbf_attr['bandwidth'], sideband=1)
@@ -640,7 +646,7 @@ class CBFIngest:
                                    self.channel_ranges.input.stop)
             freqs = spw.channel_freqs << u.Hz
 
-            rfi_mask_model_key = self.telstate.join('model', 'rfi_mask', 'fixed')
+            rfi_mask_model_key = telstate.join('model', 'rfi_mask', 'fixed')
             try:
                 rfi_mask_model = fetcher.get(rfi_mask_model_key, katsdpmodels.rfi_mask.RFIMask)
             except (requests.exceptions.RequestException, katsdpmodels.models.ModelError) as exc:
@@ -651,7 +657,7 @@ class CBFIngest:
             else:
                 bls = self.bls_ordering.sdp_bls_ordering
                 antenna_names = set(input_name[:-1] for input_name in bls.flat)
-                antennas = [katpoint.Antenna(self.telstate['{}_observer'.format(name)])
+                antennas = [katpoint.Antenna(telstate['{}_observer'.format(name)])
                             for name in antenna_names]
                 ref = antennas[0].array_reference_antenna()
                 # Turn each antenna into a location East/North/Up of the reference
@@ -668,10 +674,10 @@ class CBFIngest:
                 self.bls_channel_mask_idx = indices.astype(np.uint32)
                 self.static_masks = masks * np.uint8(STATIC)
 
-            band_mask_model_key = self.telstate.join('model', 'band_mask', 'fixed')
+            band_mask_model_key = telstate.join('model', 'band_mask', 'fixed')
             try:
                 band_mask_model = fetcher.get(band_mask_model_key, katsdpmodels.band_mask.BandMask,
-                                              telstate=self.telstate_cbf)
+                                              telstate=telstate_cbf)
             except (requests.exceptions.RequestException, katsdpmodels.models.ModelError) as exc:
                 logger.warning('Failed to load band_mask model: %s', exc, exc_info=True)
             else:
@@ -684,13 +690,11 @@ class CBFIngest:
 
     def _init_time_averaging(self, output_int_time: float, sd_int_time: float) -> None:
         output_ratio = max(1, int(round(output_int_time / self.cbf_attr['int_time'])))
-        self._output_avg = _TimeAverage(output_ratio)
-        self._output_avg.flush = self._flush_output   # type: ignore
+        self._output_avg = _TimeAverage(output_ratio, self._flush_output)
         logger.info("Averaging {0} input dumps per output dump".format(self._output_avg.ratio))
 
         sd_ratio = max(1, int(round(sd_int_time / self.cbf_attr['int_time'])))
-        self._sd_avg = _TimeAverage(sd_ratio)
-        self._sd_avg.flush = self._flush_sd           # type: ignore
+        self._sd_avg = _TimeAverage(sd_ratio, self._flush_sd)
         logger.info("Averaging {0} input dumps per signal display dump".format(
                     self._sd_avg.ratio))
 
@@ -779,7 +783,7 @@ class CBFIngest:
         cont_factor : int
             Continuum factor (1 for spectral product)
         """
-        endpoints = getattr(args, 'l0_{}_spead'.format(arg_name))
+        endpoints: List[Endpoint] = getattr(args, 'l0_{}_spead'.format(arg_name))
         if not endpoints:
             return
 
@@ -793,8 +797,8 @@ class CBFIngest:
         if len(endpoints) % args.servers:
             raise ValueError('Number of endpoints ({}) not divisible by number of servers ({})'
                              .format(len(endpoints), args.servers))
-        endpoint_lo = (args.server_id - 1) * len(endpoints) // args.servers
-        endpoint_hi = args.server_id * len(endpoints) // args.servers
+        endpoint_lo: int = (args.server_id - 1) * len(endpoints) // args.servers
+        endpoint_hi: int = args.server_id * len(endpoints) // args.servers
         endpoints = endpoints[endpoint_lo:endpoint_hi]
         logger.info('Sending %s output to %s', arg_name, endpoints_to_str(endpoints))
         int_time = self.cbf_attr['int_time'] * self._output_avg.ratio
@@ -811,8 +815,8 @@ class CBFIngest:
 
         # Put attributes into telstate. This will be done by all the ingest
         # nodes, with the same values.
-        prefix = getattr(args, 'l0_{}_name'.format(arg_name))
-        view = self.telstate.view(prefix)
+        prefix: str = getattr(args, 'l0_{}_name'.format(arg_name))
+        view: katsdptelstate.TelescopeState = args.telstate.view(prefix)
         cbf_spw = SpectralWindow(
             self.cbf_attr['center_freq'], None, len(self.channel_ranges.cbf),
             bandwidth=self.cbf_attr['bandwidth'], sideband=1)
@@ -824,12 +828,12 @@ class CBFIngest:
         utils.set_telstate_entry(view, 'n_bls', baselines)
         utils.set_telstate_entry(view, 'bls_ordering', self.bls_ordering.sdp_bls_ordering)
         utils.set_telstate_entry(view, 'sync_time', self.cbf_attr['sync_time'])
-        utils.set_telstate_entry(view, 'bandwidth', output_spw.bandwidth, prefix)
-        utils.set_telstate_entry(view, 'center_freq', output_spw.centre_freq, prefix)
-        utils.set_telstate_entry(view, 'channel_range', all_output.astuple(), prefix)
-        utils.set_telstate_entry(view, 'int_time', int_time, prefix)
-        utils.set_telstate_entry(view, 'excise', args.excise, prefix)
-        utils.set_telstate_entry(view, 'src_streams', [self.src_stream], prefix)
+        utils.set_telstate_entry(view, 'bandwidth', output_spw.bandwidth)
+        utils.set_telstate_entry(view, 'center_freq', output_spw.centre_freq)
+        utils.set_telstate_entry(view, 'channel_range', all_output.astuple())
+        utils.set_telstate_entry(view, 'int_time', int_time)
+        utils.set_telstate_entry(view, 'excise', args.excise)
+        utils.set_telstate_entry(view, 'src_streams', [self.src_stream])
         utils.set_telstate_entry(view, 'stream_type', 'sdp.vis')
         utils.set_telstate_entry(view, 'calibrations_applied', [])
         utils.set_telstate_entry(view, 'need_weights_power_scale', True)
@@ -837,8 +841,8 @@ class CBFIngest:
         self.l0_names.append(prefix)
 
     def _init_tx(self, args: argparse.Namespace) -> None:
-        self.tx = {}          # type: Dict[str, sender.VisSenderSet]
-        self.l0_names = []    # type: List[str]
+        self.tx: Dict[str, sender.VisSenderSet] = {}
+        self.l0_names: List[str] = []
         self._init_tx_one(args, 'spectral', 'spec', 1)
         self._init_tx_one(args, 'continuum', 'cont', self.channel_ranges.cont_factor)
 
@@ -941,30 +945,38 @@ class CBFIngest:
                  channel_ranges: ChannelRanges,
                  context,
                  my_sensors: Mapping[str, Sensor],
-                 telstate: katsdptelstate.TelescopeState) -> None:
-        self._sdisp_ips = {}       # type: Dict[str, spead2.send.asyncio.UdpStream]
-        self._run_future = None    # type: Optional[asyncio.Task]
+                 telstate: katsdptelstate.aio.TelescopeState) -> None:
+        self._sdisp_ips: Dict[str, spead2.send.asyncio.UdpStream] = {}
+        self._run_future: Optional[asyncio.Task] = None
         # Set by stop to abort prior to creating the receiver
         self._stopped = True
-        self.capture_block_id = None    # type: Optional[str]
+        self.capture_block_id: Optional[str] = None
 
-        self.rx_spead_endpoints = args.cbf_spead
+        self.rx_spead_endpoints: List[Endpoint] = args.cbf_spead
         self.rx_spead_ifaddr = katsdpservices.get_interface_address(args.cbf_interface)
-        self.rx_spead_ibv = args.cbf_ibv
-        self.rx_spead_max_streams = args.input_streams
-        self.rx_spead_max_packet_size = args.input_max_packet_size
-        self.rx_spead_buffer_size = args.input_buffer
-        self.sd_spead_rate = args.sd_spead_rate / args.clock_ratio if args.clock_ratio else 0.0
+        self.rx_spead_ibv: bool = args.cbf_ibv
+        self.rx_spead_max_streams: int = args.input_streams
+        self.rx_spead_max_packet_size: int = args.input_max_packet_size
+        self.rx_spead_buffer_size: int = args.input_buffer
+        self.sd_spead_rate: float = (
+            args.sd_spead_rate / args.clock_ratio if args.clock_ratio else 0.0
+        )
         self.sd_spead_ifaddr = katsdpservices.get_interface_address(args.sdisp_interface)
         self.channel_ranges = channel_ranges
         self.telstate = telstate
-        self.telstate_cbf = utils.cbf_telstate_view(telstate, args.cbf_name)
+        # A bit of hackery to get a view of the async telstate without awaiting
+        # anything: we'll obtain the view from the synchronous telstate, then
+        # transfer the prefixes.
+        self.telstate_cbf = katsdptelstate.aio.TelescopeState(
+            prefixes=utils.cbf_telstate_view(args.telstate, args.cbf_name).prefixes,
+            backend=telstate.backend
+        )
         self.telstate_sdisp = telstate.view('sdp', exclusive=True).view(args.l0_spectral_name)
         self.cbf_attr = cbf_attr
-        self.src_stream = args.cbf_name
-        self.use_data_suspect = args.use_data_suspect
+        self.src_stream: str = args.cbf_name
+        self.use_data_suspect: bool = args.use_data_suspect
 
-        self._init_baselines(args.antenna_mask)
+        self._init_baselines(args.telstate, args.antenna_mask)
         self._init_time_averaging(args.output_int_time, args.sd_int_time)
         self._init_sensors(my_sensors)
         self._init_tx(args)  # Note: must be run after _init_time_averaging, before _init_proc
@@ -973,13 +985,13 @@ class CBFIngest:
 
         # Instantiation of input streams is delayed until the asynchronous task
         # is running, to avoid receiving data we're not yet ready for.
-        self.rx = None       # type: Optional[receiver.Receiver]
+        self.rx: Optional[receiver.Receiver] = None
         self._init_ig_sd()
 
         # Record information about the processing in telstate
         if args.name is not None:
             descriptions = _fix_descriptions(list(self.proc.descriptions()))
-            process_view = self.telstate.view(args.name.replace('.', '_'))
+            process_view = args.telstate.view(args.name.replace('.', '_'))
             utils.set_telstate_entry(process_view, 'process_log', descriptions)
 
     def enable_debug(self, debug: bool) -> None:
@@ -1026,7 +1038,7 @@ class CBFIngest:
         if self.capturing:
             await self._stop_stream(stream, self.ig_sd)
 
-    def add_sdisp_ip(self, endpoint: katsdptelstate.endpoint.Endpoint) -> None:
+    def add_sdisp_ip(self, endpoint: Endpoint) -> None:
         """Add a new server to the signal display list.
 
         Parameters
@@ -1044,7 +1056,7 @@ class CBFIngest:
         config = spead2.send.StreamConfig(max_packet_size=8872, rate=self.sd_spead_rate / 8)
         logger.info("Adding %s to signal display list. Starting stream...", endpoint)
         if self.sd_spead_ifaddr is None:
-            extra_args = {}     # type: Dict[str, Any]
+            extra_args: Dict[str, Any] = {}
         else:
             extra_args = dict(ttl=1, interface_address=self.sd_spead_ifaddr)
         stream = spead2.send.asyncio.UdpStream(
@@ -1063,7 +1075,7 @@ class CBFIngest:
         stop = time.monotonic()
         self.telstate_time_sensor.value += stop - start
 
-    def _flush_output(self, output_idx: int):
+    async def _flush_output(self, output_idx: int) -> None:
         """Finalise averaging of a group of input dumps and emit an output dump"""
         proc_a = self.proc_resource.acquire()
         output_a, host_output_a = self.output_resource.acquire()
@@ -1090,9 +1102,9 @@ class CBFIngest:
             self.command_queue.enqueue_wait_for_events(events)
 
             # Transfer
-            data = {}   # type: Dict[str, sender.Data]
+            data: Dict[str, sender.Data] = {}
             for prefix in self.tx:
-                kwargs = {}   # type: Dict[str, np.ndarray]
+                kwargs: Dict[str, np.ndarray] = {}
                 for field in ['vis', 'flags', 'weights', 'weights_channel']:
                     name = prefix + '_' + field
                     kwargs[field] = host_output[name]
@@ -1129,14 +1141,14 @@ class CBFIngest:
             host_output_a.ready()
             logger.debug("Finished dump group with index %d", output_idx)
 
-    def _flush_sd(self, output_idx: int) -> None:
+    async def _flush_sd(self, output_idx: int) -> None:
         """Finalise averaging of a group of dumps for signal display, and send
         signal display data to the signal display server"""
         all_channels = len(self.channel_ranges.all_sd_output)
         try:
             with self.time_telstate():
                 custom_signals_indices = np.array(
-                    self.telstate_sdisp['sdisp_custom_signals'],
+                    await self.telstate_sdisp['sdisp_custom_signals'],
                     dtype=np.uint32, copy=False)
         except KeyError:
             custom_signals_indices = np.array([], dtype=np.uint32)
@@ -1144,7 +1156,7 @@ class CBFIngest:
         try:
             with self.time_telstate():
                 full_mask = np.array(
-                    self.telstate_sdisp['sdisp_timeseries_mask'],
+                    await self.telstate_sdisp['sdisp_timeseries_mask'],
                     dtype=np.float32, copy=False)
             if full_mask.shape != (all_channels,):
                 raise ValueError
@@ -1280,20 +1292,20 @@ class CBFIngest:
             host_sd_output_a.ready()
             logger.debug("Finished SD group with index %d", output_idx)
 
-    def _set_external_flags(self, baseline_flags: np.ndarray, channel_mask: np.ndarray,
-                            timestamp: float) -> None:
+    async def _set_external_flags(self, baseline_flags: np.ndarray, channel_mask: np.ndarray,
+                                  timestamp: float) -> None:
         """Query telstate for per-baseline flags and per-channel flags to set.
 
         The last value set prior to the end of the dump is used.
         """
-        def sensor_value(telstate, name):
+        async def sensor_value(telstate: katsdptelstate.aio.TelescopeState, name: str) -> Any:
             value = None
             if telstate is None:
                 return None
             if name not in cache:
                 try:
                     with self.time_telstate():
-                        values = telstate.get_range(name, et=end_time)
+                        values = await telstate.get_range(name, et=end_time)
                     value = values[-1][0]     # Last entry, value element of pair
                 except (KeyError, IndexError):
                     pass
@@ -1305,13 +1317,13 @@ class CBFIngest:
             else:
                 return cache[name]
 
-        cache = {}   # type: Dict[str, Any]
+        cache: Dict[str, Any] = {}
         static_flag = np.uint8(STATIC)
         cam_flag = np.uint8(CAM)
         end_time = timestamp + self.cbf_attr['int_time']
         channel_slice = self.channel_ranges.input.asslice()
 
-        channel_mask_sensor = sensor_value(self.telstate_cbf, 'channel_mask')
+        channel_mask_sensor = await sensor_value(self.telstate_cbf, 'channel_mask')
         if channel_mask_sensor is not None:
             if channel_mask_sensor.ndim == 2:
                 logger.warning('2D channel_mask is no longer supported - update katsdpcam2telstate')
@@ -1322,15 +1334,15 @@ class CBFIngest:
             channel_mask[:] = self.static_masks
 
         if self.use_data_suspect:
-            channel_data_suspect = sensor_value(self.telstate_cbf, 'channel_data_suspect')
+            channel_data_suspect = await sensor_value(self.telstate_cbf, 'channel_data_suspect')
             if channel_data_suspect is not None:
                 channel_mask[:] |= channel_data_suspect[np.newaxis, channel_slice] * cam_flag
 
         baselines = self.bls_ordering.sdp_bls_ordering
         input_labels = self.cbf_attr['input_labels']
-        input_suspect = {}    # type: Dict[str, bool]
+        input_suspect: Dict[str, bool] = {}
         if self.use_data_suspect:
-            input_suspect_sensor = sensor_value(
+            input_suspect_sensor = await sensor_value(
                 self.telstate_cbf, 'input_data_suspect')
             if input_suspect_sensor is not None:
                 input_suspect = {label: input_suspect_sensor[i]
@@ -1342,7 +1354,7 @@ class CBFIngest:
             b = baseline[1][:-1]
             flagged = False
             for antenna in (a, b):
-                if sensor_value(self.telstate, '{}_data_suspect'.format(antenna)):
+                if await sensor_value(self.telstate, '{}_data_suspect'.format(antenna)):
                     flagged = True
             for input_ in baseline:
                 if input_suspect.get(input_):
@@ -1378,7 +1390,7 @@ class CBFIngest:
                 # higher than PCIe transfer bandwidth that it doesn't really
                 # cost much more to zero-fill the entire buffer.
                 vis_in_buffer.zero(self.command_queue)
-            self._set_external_flags(baseline_flags, channel_mask, frame.timestamp)
+            await self._set_external_flags(baseline_flags, channel_mask, frame.timestamp)
             for item in frame.items:
                 item_range = utils.Range(item_channel, item_channel + channels_per_item)
                 item_channel = item_range.stop
@@ -1514,8 +1526,8 @@ class CBFIngest:
             current_ts = self.cbf_attr['sync_time'] + current_ts_rel
             self._my_sensors["last-dump-timestamp"].value = current_ts
 
-            self._output_avg.add_index(frame.idx)
-            self._sd_avg.add_index(frame.idx)
+            await self._output_avg.add_index(frame.idx)
+            await self._sd_avg.add_index(frame.idx)
 
             proc_a = self.proc_resource.acquire()
             input_a, host_input_a = self.input_resource.acquire()
@@ -1540,8 +1552,8 @@ class CBFIngest:
         # Ensure we have clean state. Some of this is unnecessary in normal
         # use, but important if the previous session crashed.
         self._zero_counters()
-        self._output_avg.finish(flush=False)
-        self._sd_avg.finish(flush=False)
+        await self._output_avg.finish(flush=False)
+        await self._sd_avg.finish(flush=False)
         self._init_ig_sd()
         # Send start-of-stream packets.
         await self._send_sd_data(self.ig_sd.get_start())
@@ -1572,8 +1584,8 @@ class CBFIngest:
         await self._get_data()
 
         logger.info('Joined with receiver. Flushing final groups...')
-        self._output_avg.finish()
-        self._sd_avg.finish()
+        await self._output_avg.finish()
+        await self._sd_avg.finish()
         logger.info('Waiting for jobs to complete...')
         await self.jobs.finish()
         logger.info('Jobs complete')

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -683,7 +683,7 @@ class CBFIngest:
     def _init_baselines(self, system_attrs: SystemAttrs) -> None:
         # Configure the masking and reordering of baselines
         self.bls_ordering = BaselineOrdering(
-            self.cbf_attr['bls_ordering'],
+            system_attrs.cbf_attr['bls_ordering'],
             [antenna.name for antenna in system_attrs.antennas]
         )
 

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -72,8 +72,7 @@ class _TimeAverage:
     cadence.
 
     This object never sees dump contents directly, only dump indices. When an
-    index is added that is not part of the current group, :func:`flush`
-    is called, which must be set to a callback function.
+    index is added that is not part of the current group, `flush` is called.
 
     Parameters
     ----------
@@ -102,8 +101,10 @@ class _TimeAverage:
         self._start_idx = idx // self.ratio * self.ratio
 
     async def add_index(self, idx: int) -> None:
-        """Record that a dump with a given index has arrived and is about to
-        be processed. This may call :func:`flush`."""
+        """Record that a dump with a given index has arrived and is about to be processed.
+
+        This may call the `flush` callback given to the constructor.
+        """
 
         if self._start_idx is None:
             self._warp_start(idx)

--- a/katsdpingest/receiver.py
+++ b/katsdpingest/receiver.py
@@ -299,7 +299,7 @@ class Receiver:
         self._add_readers(stream, endpoints, max_packet_size, buffer_size)
         return stream
 
-    def _first_timestamp(self, candidate: int) -> int:
+    async def _first_timestamp(self, candidate: int) -> int:
         """Get raw ADC timestamp of the first frame across all ingests.
 
         This is called when the first valid dump is received for this
@@ -421,7 +421,7 @@ class Receiver:
                               data_ts, stream_idx, channel0)
                 prev_ts = data_ts
                 if not self._frames:
-                    self.timestamp_base = self._first_timestamp(data_ts)
+                    self.timestamp_base = await self._first_timestamp(data_ts)
                     for i in range(self.active_frames):
                         self._frames.append(
                             Frame(i, self.timestamp_base + self.interval * i, xengs))

--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -4,7 +4,8 @@ from typing import List, Tuple, Iterable, Mapping, Callable, Optional, Generator
 
 import pkg_resources
 import numpy as np
-from katsdpsigproc import accel, tune, fill, transpose, percentile, maskedsum, reduce, rfi
+from katsdpsigproc import accel, tune, fill, transpose, percentile, maskedsum, reduce
+import katsdpsigproc.rfi.device
 from katsdpsigproc.abc import AbstractContext, AbstractCommandQueue
 from katdal.flags import CAL_RFI, CAM
 
@@ -1263,7 +1264,8 @@ class IngestTemplate:
         Perform continuum averaging of L0 data.
     """
 
-    def __init__(self, context: AbstractContext, flagger: rfi.device.FlaggerDeviceTemplate,
+    def __init__(self, context: AbstractContext,
+                 flagger: katsdpsigproc.rfi.device.FlaggerDeviceTemplate,
                  percentile_sizes: Iterable[int], excise: bool, continuum: bool) -> None:
         self.context = context
         self.prepare = PrepareTemplate(context)

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -17,7 +17,6 @@ import spead2
 import spead2.recv
 import spead2.send
 import aiokatcp
-import katsdptelstate.memory
 import katsdptelstate.aio.memory
 from katsdptelstate.endpoint import Endpoint
 from katsdpsigproc.test.test_accel import device_test

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -197,11 +197,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         done_future = asyncio.Future(loop=self.loop)     # type: asyncio.Future[None]
         done_future.set_result(None)
         self._patchers = []                              # type: List[Any]
-        telstate_backend = katsdptelstate.memory.MemoryBackend()
-        self._telstate = katsdptelstate.TelescopeState(telstate_backend)
-        self._async_telstate = katsdptelstate.aio.TelescopeState(
-            katsdptelstate.aio.memory.MemoryBackend.from_sync(telstate_backend)
-        )
+        self._telstate = katsdptelstate.aio.TelescopeState()
         n_xengs = 16
         self.user_args = user_args = argparse.Namespace(
             sdisp_spead=[Endpoint('127.0.0.2', 7149)],
@@ -235,24 +231,23 @@ class TestIngestDeviceServer(asynctest.TestCase):
             clock_ratio=1.0,
             host='127.0.0.1',
             port=7147,
-            telstate=self._telstate,
             name='sdp.ingest.1'
         )
         self.cbf_attr = fake_cbf_attr(4, n_xengs=n_xengs)
         # Put them in at the beginning of time, to ensure they apply to every dump
-        self._telstate['i0_baseline_correlation_products_src_streams'] = \
-            ['i0_antenna_channelised_voltage']
-        self._telstate['i0_antenna_channelised_voltage_instrument_dev_name'] = 'i0'
-        self._telstate.add('i0_antenna_channelised_voltage_channel_mask',
-                           self.fake_channel_mask(), ts=0)
-        self._telstate.add('m090_data_suspect', False, ts=0)
-        self._telstate.add('m091_data_suspect', True, ts=0)
+        await self._telstate.set('i0_baseline_correlation_products_src_streams',
+                                 ['i0_antenna_channelised_voltage'])
+        await self._telstate.set('i0_antenna_channelised_voltage_instrument_dev_name', 'i0')
+        await self._telstate.add('i0_antenna_channelised_voltage_channel_mask',
+                                 self.fake_channel_mask(), ts=0)
+        await self._telstate.add('m090_data_suspect', False, ts=0)
+        await self._telstate.add('m091_data_suspect', True, ts=0)
         input_data_suspect = np.zeros(len(self.cbf_attr['input_labels']), np.bool_)
         input_data_suspect[1] = True     # Corresponds to m090v
-        self._telstate.add('i0_antenna_channelised_voltage_input_data_suspect',
-                           input_data_suspect, ts=0)
-        self._telstate.add('i0_baseline_correlation_products_channel_data_suspect',
-                           self.fake_channel_data_suspect(), ts=0)
+        await self._telstate.add('i0_antenna_channelised_voltage_input_data_suspect',
+                                 input_data_suspect, ts=0)
+        await self._telstate.add('i0_baseline_correlation_products_channel_data_suspect',
+                                 self.fake_channel_data_suspect(), ts=0)
         # These correspond to three core and one outlying MeerKAT antennas,
         # so that baselines to m093 are long while the others are short.
         antennas = [
@@ -261,7 +256,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
             katpoint.Antenna('m002, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, -32.1085 -224.2365 1.248 5871.207 5872.205, 0:40:20.2 0 -0:02:41.9 -0:03:46.8 0:00:09.4 -0:00:01.1 0:03:04.7, 1.14'),              # noqa: E501
             katpoint.Antenna('m093, -30:42:39.8, 21:26:38.0, 1035.0, 13.5, -1440.6235 -2503.7705 14.288 5932.94 5934.732, -0:15:23.0 0 0:00:04.6 -0:03:30.4 0:01:12.2 0:00:37.5 0:00:15.6 0:01:11.8, 1.14')   # noqa: E501
         ]
-        self._telstate_cbf = await cbf_telstate_view(self._async_telstate,
+        self._telstate_cbf = await cbf_telstate_view(self._telstate,
                                                      'i0_baseline_correlation_products')
         self.system_attrs = SystemAttrs(
             self.cbf_attr, self.fake_rfi_mask_model(), self.fake_band_mask_model(),
@@ -329,7 +324,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
             with async_timeout.timeout(15):
                 await self._client.request(name, *args)
 
-    def _get_expected(self):
+    async def _get_expected(self):
         """Return expected visibilities, flags and timestamps.
 
         The timestamps are in seconds since the sync time. The full CBF channel
@@ -340,13 +335,14 @@ class TestIngestDeviceServer(asynctest.TestCase):
         # Scaling
         vis /= self.cbf_attr['n_accs']
         # Time averaging
-        time_ratio = int(np.round(self._telstate['sdp_l0_int_time'] / self.cbf_attr['int_time']))
+        time_ratio = int(np.round(await self._telstate['sdp_l0_int_time']
+                                  / self.cbf_attr['int_time']))
         batch_edges = np.arange(0, vis.shape[0], time_ratio)
         batch_sizes = np.minimum(batch_edges + time_ratio, vis.shape[0]) - batch_edges
         vis = np.add.reduceat(vis, batch_edges, axis=0)
         vis /= batch_sizes[:, np.newaxis, np.newaxis]
         timestamps = self._timestamps[::time_ratio] / self.cbf_attr['scale_factor_timestamp'] \
-            + 0.5 * self._telstate['sdp_l0_int_time']
+            + 0.5 * (await self._telstate['sdp_l0_int_time'])
         # Baseline permutation
         bls = BaselineOrdering(self.cbf_attr['bls_ordering'], self.user_args.antenna_mask)
         inv_permutation = np.empty(len(bls.sdp_bls_ordering), np.int)
@@ -356,7 +352,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         vis = vis[..., inv_permutation]
         # Sanity check that we've constructed inv_permutation correctly
         np.testing.assert_array_equal(
-            self._telstate['sdp_l0_bls_ordering'],
+            await self._telstate['sdp_l0_bls_ordering'],
             self.cbf_attr['bls_ordering'][inv_permutation])
         flags = np.empty(vis.shape, np.uint8)
         channel_mask = self.fake_channel_mask()
@@ -400,10 +396,10 @@ class TestIngestDeviceServer(asynctest.TestCase):
             assert_equal(i, idx)
             assert_almost_equal(ts, ts_rel)
 
-    def test_init_telstate(self):
+    async def test_init_telstate(self):
         """Test the output metadata in telstate"""
-        def get_ts(key):
-            return self._telstate[prefix + '_' + key]
+        async def get_ts(key):
+            return await self._telstate[prefix + '_' + key]
 
         bls_ordering = []
         for a in self.user_args.antenna_mask:
@@ -415,17 +411,17 @@ class TestIngestDeviceServer(asynctest.TestCase):
         bls_ordering.sort()
         for prefix in ['sdp_l0', 'sdp_l0_continuum']:
             factor = 1 if prefix == 'sdp_l0' else self.user_args.continuum_factor
-            assert_equal(1280 // factor, get_ts('n_chans'))
-            assert_equal(get_ts('n_chans') // 4, get_ts('n_chans_per_substream'))
-            assert_equal(len(bls_ordering), get_ts('n_bls'))
-            assert_equal(bls_ordering, sorted(get_ts('bls_ordering').tolist()))
-            assert_equal(self.cbf_attr['sync_time'], get_ts('sync_time'))
-            assert_equal(267500000.0, get_ts('bandwidth'))
-            assert_equal(8 * self.cbf_attr['int_time'], get_ts('int_time'))
-            assert_equal((464, 1744), get_ts('channel_range'))
-        assert_equal(1086718750.0, self._telstate['sdp_l0_center_freq'])
+            assert_equal(1280 // factor, await get_ts('n_chans'))
+            assert_equal((await get_ts('n_chans')) // 4, await get_ts('n_chans_per_substream'))
+            assert_equal(len(bls_ordering), await get_ts('n_bls'))
+            assert_equal(bls_ordering, sorted((await get_ts('bls_ordering')).tolist()))
+            assert_equal(self.cbf_attr['sync_time'], await get_ts('sync_time'))
+            assert_equal(267500000.0, await get_ts('bandwidth'))
+            assert_equal(8 * self.cbf_attr['int_time'], await get_ts('int_time'))
+            assert_equal((464, 1744), await get_ts('channel_range'))
+        assert_equal(1086718750.0, await self._telstate['sdp_l0_center_freq'])
         # Offset by 7.5 channels to identify the centre of a continuum channel
-        assert_equal(1088286132.8125, self._telstate['sdp_l0_continuum_center_freq'])
+        assert_equal(1088286132.8125, await self._telstate['sdp_l0_continuum_center_freq'])
 
     async def test_capture(self):
         """Test the core data capture process."""
@@ -433,7 +429,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         await self.make_request('capture-done')
         l0_flavour = spead2.Flavour(4, 64, 48)
         l0_int_time = 8 * self.cbf_attr['int_time']
-        expected_vis, expected_flags, expected_ts = self._get_expected()
+        expected_vis, expected_flags, expected_ts = await self._get_expected()
         expected_output_vis = expected_vis[:, self.channel_ranges.output.asslice(), :]
         expected_output_flags = expected_flags[:, self.channel_ranges.output.asslice(), :]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aioconsole                # via aiomonitor
 aiokatcp
 aiomonitor
-aioredis                  # via katsdptelstate[aio]
+aioredis==1.3.1           # via katsdptelstate[aio]
 appdirs                   # via katsdpsigproc
 astropy                   # via katsdpmodels
 async-timeout             # via aiokatcp, aioredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 aioconsole                # via aiomonitor
 aiokatcp
 aiomonitor
+aioredis                  # via katsdptelstate[aio]
 appdirs                   # via katsdpsigproc
 astropy                   # via katsdpmodels
-async-timeout             # via aiokatcp
+async-timeout             # via aiokatcp, aioredis
 certifi                   # via requests
 chardet                   # via requests
 cityhash                  # via katdal
@@ -12,7 +13,7 @@ decorator                 # via katsdpsigproc
 ephem                     # via pyephem
 future                    # via katdal
 h5py                      # via katdal, katsdpmodels
-hiredis                   # via katsdptelstate
+hiredis                   # via katsdptelstate, aioredis
 idna                      # via requests
 katversion
 llvmlite                  # via numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
 aioconsole                # via aiomonitor
+aiohttp                   # via katsdpmodels
 aiokatcp
 aiomonitor
 aioredis==1.3.1           # via katsdptelstate[aio]
 appdirs                   # via katsdpsigproc
 astropy                   # via katsdpmodels
-async-timeout             # via aiokatcp, aioredis
+async-timeout             # via aiokatcp, aioredis, aiohttp
+attrs                     # via aiohttp
 certifi                   # via requests
-chardet                   # via requests
+chardet                   # via requests, aiohttp
 cityhash                  # via katdal
 dask                      # via katdal
 decorator                 # via katsdpsigproc
@@ -15,11 +17,13 @@ future                    # via katdal
 h5py                      # via katdal, katsdpmodels
 hiredis                   # via katsdptelstate, aioredis
 idna                      # via requests
+idna-ssl                  # via aiohttp
 katversion
 llvmlite                  # via numba
 Mako                      # via katsdpsigproc
 MarkupSafe                # via mako
 msgpack                   # via katsdptelstate
+multidict                 # via aiohttp
 netifaces                 # via katsdptelstate
 numba                     # via katsdpsigproc
 numpy
@@ -32,15 +36,17 @@ python-dateutil           # via pandas
 pytools                   # via pycuda
 pytz                      # via pandas
 redis                     # via katsdptelstate
-requests                  # via katdal, katsdpmodels
+requests                  # via katdal
 scipy                     # via katsdpsigproc
 six                       # via spead2 (and probably others)
 spead2
 strict-rfc3339            # via katsdpmodels
 terminaltables            # via aiomonitor
-typing_extensions         # via katsdpsigproc, katsdpmodels
+typing_extensions         # via katsdpsigproc, katsdpmodels, aiohttp
 toolz                     # via dask
 urllib3                   # via requests
+yarl                      # via aiohttp
+
 # TODO: eventually switch to using a release of katdal, once the enhanced
 # SpectralWindow class has shipped.
 katdal @ git+https://github.com/ska-sa/katdal

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -3,7 +3,6 @@
 # Capture utility for a relatively generic packetised correlator data output stream.
 
 import logging
-import sys
 import signal
 import asyncio
 import argparse
@@ -14,9 +13,10 @@ from katsdpsigproc import accel
 import aioredis
 from katsdptelstate import endpoint
 import katsdptelstate.aio.redis
+import katsdpmodels.fetch.aiohttp
 
-from katsdpingest.ingest_session import ChannelRanges, get_cbf_attr
-from katsdpingest.utils import Range
+from katsdpingest.ingest_session import ChannelRanges, SystemAttrs
+from katsdpingest.utils import Range, cbf_telstate_view
 from katsdpingest.ingest_server import IngestDeviceServer
 
 
@@ -177,28 +177,26 @@ async def main() -> None:
         logging.root.setLevel(args.log_level.upper())
 
     loop = asyncio.get_event_loop()
-    try:
-        cbf_attr = get_cbf_attr(args.telstate, args.cbf_name)
-    except KeyError as error:
-        logger.error('Terminating due to catastrophic failure: %s', str(error))
-        sys.exit(1)
-    cbf_channels = cbf_attr['n_chans']
-    if args.output_channels is None:
-        args.output_channels = Range(0, cbf_channels)
-    if args.sd_output_channels is None:
-        args.sd_output_channels = Range(0, cbf_channels)
-    # If no continuum product is selected, set continuum factor to 1 since
-    # that effectively disables the alignment checks.
-    continuum_factor = args.continuum_factor if args.l0_continuum_spead else 1
-    # TODO: determine an appropriate value for guard
-    channel_ranges = ChannelRanges(
-        args.servers, args.server_id - 1,
-        cbf_channels, continuum_factor, args.sd_continuum_factor,
-        len(args.cbf_spead), args.guard_channels, args.output_channels, args.sd_output_channels)
-    context = accel.create_some_context(interactive=False)
     telstate = await get_async_telstate(args.telstate_endpoint)
-    server = IngestDeviceServer(args, telstate, channel_ranges, cbf_attr, context,
-                                args.host, args.port)
+    telstate_cbf = await cbf_telstate_view(telstate, args.cbf_name)
+    async with katsdpmodels.fetch.aiohttp.TelescopeStateFetcher(telstate) as fetcher:
+        system_attrs = await SystemAttrs.create(fetcher, telstate_cbf, args.antenna_mask)
+        cbf_channels = system_attrs.cbf_attr['n_chans']
+        if args.output_channels is None:
+            args.output_channels = Range(0, cbf_channels)
+        if args.sd_output_channels is None:
+            args.sd_output_channels = Range(0, cbf_channels)
+        # If no continuum product is selected, set continuum factor to 1 since
+        # that effectively disables the alignment checks.
+        continuum_factor = args.continuum_factor if args.l0_continuum_spead else 1
+        # TODO: determine an appropriate value for guard
+        channel_ranges = ChannelRanges(
+            args.servers, args.server_id - 1,
+            cbf_channels, continuum_factor, args.sd_continuum_factor,
+            len(args.cbf_spead), args.guard_channels, args.output_channels, args.sd_output_channels)
+        context = accel.create_some_context(interactive=False)
+        server = IngestDeviceServer(args, telstate_cbf, channel_ranges, system_attrs, context,
+                                    args.host, args.port)
 
     loop.add_signal_handler(signal.SIGINT, lambda: loop.create_task(on_shutdown(server)))
     loop.add_signal_handler(signal.SIGTERM, lambda: loop.create_task(on_shutdown(server)))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'katsdptelstate[aio]',
         'katpoint',
         'katdal',
-        'katsdpmodels[requests]'
+        'katsdpmodels[aiohttp]'
     ],
     extras_require={
         'test': tests_require

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'spead2>=1.8.0',     # Needed for inproc transport for unit tests
         'katsdpsigproc',
         'katsdpservices[argparse,aiomonitor]',
-        'katsdptelstate',
+        'katsdptelstate[aio]',
         'katpoint',
         'katdal',
         'katsdpmodels[requests]'


### PR DESCRIPTION
This doesn't have any significant immediate benefits, but it sets the scene for making things more robust when telstate has high latency e.g. by not waiting.

The code had to change quite substantially because constructors can't be asynchronous, and the CBFIngest constructor had a lot of interaction with telstate. This is resolved by
- adding a SystemAttrs class which holds the static configuration that is queried from telstate on startup (and which has an asynchronous factory function to build it); and
- keeping a log of items to add to telstate, and using a separate `populate_telstate` method to actually add them after construction.

I went through a number of iterations on this and there may be some left-over warts - if something looks odd or appears to have changed for no good reason, please point it out.