### PR TITLE
Fix some issues in SensorHistory

### DIFF
--- a/katsdpingest/receiver.py
+++ b/katsdpingest/receiver.py
@@ -90,7 +90,7 @@ class Receiver:
         Value of `active_frames` passed to constructor
     interval : int
         Timestamp change between successive frames.
-    timestamp_base : int
+    timestamp_base : Optional[int]
         Timestamp associated with the frame with index 0. It is initially
         ``None``, and is set when the first dump is received. The raw
         timestamp of any other frame can be computed as
@@ -149,7 +149,7 @@ class Receiver:
         self._futures = []      # type: List[Optional[asyncio.Future]]
         self._stopping = False
         self.interval = cbf_attr['ticks_between_spectra'] * cbf_attr['n_accs']
-        self.timestamp_base = 0
+        self.timestamp_base = None
         self._loop = loop
         self._ig_cbf = spead2.ItemGroup()
 

--- a/katsdpingest/test/test_ingest_session.py
+++ b/katsdpingest/test/test_ingest_session.py
@@ -207,44 +207,43 @@ class TestSensorHistory:
         self.sh = ingest_session.SensorHistory('test')
 
     def test_simple(self) -> None:
-        self.sh.add(4, 'hello')
-        self.sh.add(6, 'world')
-        assert_equal(self.sh.get(4), 'hello')
-        assert_equal(self.sh.get(5), 'hello')
-        assert_equal(self.sh.get(6), 'world')
-        assert_equal(self.sh.get(7), 'world')
+        self.sh.add(4.0, 'hello')
+        self.sh.add(6.0, 'world')
+        assert_equal(self.sh.get(4.0), 'hello')
+        assert_equal(self.sh.get(5.0), 'hello')
+        assert_equal(self.sh.get(6.0), 'world')
+        assert_equal(self.sh.get(7.0), 'world')
         assert_equal(len(self.sh._data), 1, 'old data was not pruned')
 
     def test_query_empty(self) -> None:
-        assert_is_none(self.sh.get(4))
-        assert_equal(self.sh.get(5, 'default'), 'default')
+        assert_is_none(self.sh.get(4.0))
+        assert_equal(self.sh.get(5.0, 'default'), 'default')
 
     def test_query_before_first(self) -> None:
-        self.sh.add(5, 'hello')
-        assert_is_none(self.sh.get(4))
+        self.sh.add(5.0, 'hello')
+        assert_is_none(self.sh.get(4.0))
 
     def test_add_before_query(self) -> None:
-        self.sh.get(5)
+        self.sh.get(5.0)
         with assert_logs(ingest_session.logger, logging.WARNING):
-            self.sh.add(5, 'oops')
-        assert_is_none(self.sh.get(5))
+            self.sh.add(4.0, 'oops')
+        assert_equal(self.sh.get(5.0), 'oops')
 
     def test_add_out_of_order(self) -> None:
-        self.sh.add(5, 'first')
+        self.sh.add(5.0, 'first')
         with assert_logs(ingest_session.logger, logging.WARNING):
-            self.sh.add(4, 'second')
+            self.sh.add(4.0, 'second')
         assert_is_none(self.sh.get(4))
 
     def test_replace_latest(self) -> None:
-        self.sh.add(5, 'first')
-        self.sh.add(5, 'second')
-        assert_equal(len(self.sh._data), 1)
-        assert_equal(self.sh.get(5), 'second')
+        self.sh.add(5.0, 'first')
+        self.sh.add(5.0, 'second')
+        assert_equal(self.sh.get(5.0), 'second')
 
     def test_query_out_of_order(self) -> None:
-        self.sh.get(5)
+        self.sh.get(5.0)
         with assert_raises(ValueError):
-            self.sh.get(4)
+            self.sh.get(4.0)
 
 
 class TestCBFIngest:


### PR DESCRIPTION
The main bug was that sensor timestamps were incorrectly converted to
dump indices, because self.rx.timestamp_base was read before it was
initialised (and hence was 0). To avoid such silent bugs in future,
timebase_base now starts life as None rather than 0.

There is a deeper design flaw, in that sensor values may be received
before the first piece of data, at which point it's impossible to
convert timestamps to dump indices. This is fixed by changing the
SensorHistory class to work with timestamps instead of dump indices.
This removes the optimisation that allowed multiple updates of a sensor
during a single dump to be collapsed.

There was a secondary bug that if a sensor sample was received "late"
(i.e. after the value was already queried for the subsequent dump), it
was dropped entirely, instead of added and used for future dumps.