### PR TITLE
Minor logging fix

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -1632,6 +1632,8 @@ class CBFIngest:
             if ts is None or new_ts > ts:
                 ts = new_ts
                 notify(value, ts)
+            elif new_ts == ts:
+                logger.warning('%s update has duplicate timestamp (%.3f) - ignoring', key, new_ts)
             else:
                 logger.warning('%s timestamp went backwards (%.3f < %.3f)', key, new_ts, ts)
             return False

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -1633,7 +1633,7 @@ class CBFIngest:
                 ts = new_ts
                 notify(value, ts)
             else:
-                logger.warning('%s timestamp went backwards (%.3f < %.3f)', new_ts, ts)
+                logger.warning('%s timestamp went backwards (%.3f < %.3f)', key, new_ts, ts)
             return False
 
         # The callback always returns false, so this call to wait_key will


### PR DESCRIPTION
I am also wondering if we should downgrade the sensor update INFO logging (specifically the two log lines in _update_sensor). This is being triggered quite regularly by the data_suspect sensors now and is a little polluting....