### PR TITLE
Pass channel width when sampling RFI and band-mask models

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -795,7 +795,8 @@ class CBFIngest:
             # Get masks as a baseline x freq array
             masks = system_attrs.rfi_mask_model.is_masked(
                 freqs[np.newaxis, :],
-                lengths[:, np.newaxis]
+                lengths[:, np.newaxis],
+                spw.channel_width * u.Hz
             )
             # Typically the model will only have a few threshold lengths, so
             # most rows will be the same. Reduce it to just unique rows, with
@@ -809,7 +810,8 @@ class CBFIngest:
                 cbf_spw.bandwidth * u.Hz,
                 cbf_spw.centre_freq * u.Hz
             )
-            mask = system_attrs.band_mask_model.is_masked(band_spw, freqs)
+            mask = system_attrs.band_mask_model.is_masked(
+                band_spw, freqs, cbf_spw.channel_width * u.Hz)
             self.static_masks |= mask[np.newaxis, :] * np.uint8(STATIC)
 
     def _init_time_averaging(self, output_int_time: float, sd_int_time: float) -> None:

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -174,7 +174,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         # Channels 852:857 and 1024
         ranges = astropy.table.QTable(
             [[1034e6, 1070.0e6] * u.Hz,
-             [1035e6, 1070.0e6] * u.Hz,
+             [1034.95e6, 1070.0e6] * u.Hz,
              [1500, np.inf] * u.m],
             names=('min_frequency', 'max_frequency', 'max_baseline')
         )
@@ -183,7 +183,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
     def fake_band_mask_model(self) -> katsdpmodels.band_mask.BandMask:
         # Channels 820:840
         ranges = astropy.table.Table(
-            [[0.2], [0.205]], names=('min_fraction', 'max_fraction')
+            [[0.2001], [0.2049]], names=('min_fraction', 'max_fraction')
         )
         return katsdpmodels.band_mask.BandMaskRanges(ranges)
 


### PR DESCRIPTION
In some cases this can result in an extra channel being masked, if less
than half of it overlaps the masked region.