### PR TITLE
One-liner to keep mypy happy with np.lib.stride_tricks

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -16,6 +16,7 @@ from typing import (
 )    # noqa: F401
 
 import numpy as np
+import numpy.lib.stride_tricks as _stride_tricks  # noqa: F401  # Keeps mypy happy
 import astropy.units as u
 import aiohttp
 


### PR DESCRIPTION
It doesn't seem to realise that one doesn't need to explicitly import
np.lib.stride_tricks.