### PR TITLE
Fix repeated computation by CompressWeights kernel

### DIFF
--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -1027,7 +1027,7 @@ class CompressWeightsTemplate:
         - wgsx, wgsy: workgroup size in each dimension
     """
 
-    autotune_version = 1
+    autotune_version = 2
 
     def __init__(self, context: AbstractContext,
                  tuning: Optional[Mapping[str, Any]] = None) -> None:
@@ -1114,8 +1114,7 @@ class CompressWeights(accel.Operation):
                 np.int32(weights_in.padded_shape[1]),
                 np.int32(self.baselines)
             ],
-            global_size=(accel.roundup(self.baselines, self.template.wgsx),
-                         accel.roundup(self.channels, self.template.wgsy)),
+            global_size=(self.template.wgsx, accel.roundup(self.channels, self.template.wgsy)),
             local_size=(self.template.wgsx, self.template.wgsy)
         )
 


### PR DESCRIPTION
The C code contains `for` loops to ensure that a single workgroup along
the baseline (fastest-varying) dimension processes the full extent of
the dimension. But the calculation of the global size didn't take this
into account, so it created multiple workgroups along this dimension.
They ended up repeating the same work, possibly hundreds of times,
making compress_weights by far the dominant use of the GPU.

I bumped the autotuning version to force tuning to be re-run, since the
previous tuning results may have been thrown off.