### PR TITLE
Speed up startup

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -165,6 +165,23 @@ def _split_array(x: np.ndarray, dtype) -> np.ndarray:
     return np.asarray(np.lib.stride_tricks.DummyArray(interface, base=x))
 
 
+def _fast_unique(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Faster version of :func:`np.unique` for specific case.
+
+    It is equivalent to ``np.unique(x, axis=0, return_inverse=True)``, where
+    ``x`` must be a 2D array.
+    """
+    # Implementation is based on
+    # https://github.com/numpy/numpy/issues/11136#issue-325345618. In short, each
+    # row is viewed as a byte string, which for some reason makes it hundreds of
+    # times faster.
+    x = np.ascontiguousarray(x)
+    new_dtype = np.dtype(f'S{x.dtype.itemsize * x.shape[1]}')
+    view = x.view(new_dtype)
+    _, index, inverse = np.unique(view, return_index=True, return_inverse=True)
+    return x[index], inverse
+
+
 def _fix_descriptions(desc: Any) -> Any:
     """Massage operation descriptions to be suitable for telstate storage.
 
@@ -802,7 +819,7 @@ class CBFIngest:
             # Typically the model will only have a few threshold lengths, so
             # most rows will be the same. Reduce it to just unique rows, with
             # a lookup table.
-            masks, indices = np.unique(masks, axis=0, return_inverse=True)
+            masks, indices = _fast_unique(masks)
             self.bls_channel_mask_idx = indices.astype(np.uint32)
             self.static_masks = masks * np.uint8(STATIC)
 

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -170,13 +170,16 @@ def _fast_unique(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
 
     It is equivalent to ``np.unique(x, axis=0, return_inverse=True)``, where
     ``x`` must be a 2D array.
+
+    It treats each row as raw binary data, so the semantics may change if there
+    are different encodings of the same value (such as -0.0 and +0.0).
     """
     # Implementation is based on
     # https://github.com/numpy/numpy/issues/11136#issue-325345618. In short, each
-    # row is viewed as a byte string, which for some reason makes it hundreds of
+    # row is viewed as a binray blob, which for some reason makes it hundreds of
     # times faster.
     x = np.ascontiguousarray(x)
-    new_dtype = np.dtype(f'S{x.dtype.itemsize * x.shape[1]}')
+    new_dtype = np.dtype((np.void, x.dtype.itemsize * x.shape[1]))
     view = x.view(new_dtype)
     _, index, inverse = np.unique(view, return_index=True, return_inverse=True)
     return x[index], inverse

--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -176,7 +176,7 @@ def _fast_unique(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """
     # Implementation is based on
     # https://github.com/numpy/numpy/issues/11136#issue-325345618. In short, each
-    # row is viewed as a binray blob, which for some reason makes it hundreds of
+    # row is viewed as a binary blob, which for some reason makes it hundreds of
     # times faster.
     x = np.ascontiguousarray(x)
     new_dtype = np.dtype((np.void, x.dtype.itemsize * x.shape[1]))

--- a/katsdpingest/test/test_ingest_session.py
+++ b/katsdpingest/test/test_ingest_session.py
@@ -7,7 +7,7 @@ from unittest import mock
 import numpy as np
 from nose.tools import (
     assert_equal, assert_is, assert_regex, assert_is_none, assert_is_not_none,
-    assert_logs, assert_raises
+    assert_logs, assert_raises, assert_true
 )
 import asynctest
 from katsdpsigproc.test.test_accel import device_test
@@ -171,6 +171,25 @@ def test_split_array():
             expected[i, j, 0] = src[i, j].real
             expected[i, j, 1] = src[i, j].imag
     np.testing.assert_equal(actual, expected)
+
+
+def test_fast_unique():
+    """Test _fast_unique."""
+    a = np.array([
+        [0, 1, 0, 0, 1, 0, 0, 1],
+        [0, 1, 0, 0, 1, 0, 1, 1],
+        [0, 1, 0, 0, 1, 0, 0, 1],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 1, 0, 0, 1],
+        [0, 1, 0, 0, 1, 0, 1, 1]
+    ], dtype=bool)
+    comp, indices = ingest_session._fast_unique(a)
+    assert_equal(comp.shape, (3, 8))
+    assert_equal(indices.shape, (7,))
+    assert_true(np.all(0 <= indices))
+    assert_true(np.all(indices < len(comp)))
+    np.testing.assert_equal(comp[indices], a)
 
 
 class TestTelstateReceiver(asynctest.TestCase):


### PR DESCRIPTION
Collapsing the RFI masks to unique channel masks used np.unique, which
possibly due to https://github.com/numpy/numpy/issues/11136 is very slow
(around 15s in the worst case for MeerKAT). The scikit-image version
from that ticket is about 500x faster.

Closes SPR1-1046.