### PR TITLE
Use katsdptelstate.aio.redis.RedisBackend.from_url

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -10,7 +10,6 @@ from typing import List, Callable, TypeVar
 
 import katsdpservices
 from katsdpsigproc import accel
-import aioredis
 from katsdptelstate import endpoint
 import katsdptelstate.aio.redis
 import katsdpmodels.fetch.aiohttp
@@ -165,8 +164,10 @@ async def on_shutdown(server: IngestDeviceServer) -> None:
 
 
 async def get_async_telstate(endpoint: katsdptelstate.endpoint.Endpoint):
-    client = await aioredis.create_redis_pool(f'redis://{endpoint.host}:{endpoint.port}')
-    return katsdptelstate.aio.TelescopeState(katsdptelstate.aio.redis.RedisBackend(client))
+    backend = await katsdptelstate.aio.redis.RedisBackend.from_url(
+        f'redis://{endpoint.host}:{endpoint.port}'
+    )
+    return katsdptelstate.aio.TelescopeState(backend)
 
 
 async def main() -> None:


### PR DESCRIPTION
This removes the direct dependency on aioredis, and so paves the way to
upgrading to 2.x.

Depends on https://github.com/ska-sa/katsdptelstate/pull/125.
