### PR TITLE
Push tuned images to Harbor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
     - id: flake8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ catchError {
                 katsdp.unpackGit()
                 katsdp.unpackVenv()
                 katsdp.unpackKatsdpdockerbase()
+                withCredentials([usernamePassword(
+                    credentialsId: 'harbor-dpp',
+                    usernameVariable: 'HARBOR_USER',
+                    passwordVariable: 'HARBOR_PASS')]) {
+                    sh 'docker login -u "$HARBOR_USER" -p "$HARBOR_PASS" "harbor.sdp.kat.ac.za"'
+                }
                 katsdp.virtualenv('venv') {
                     dir('git') {
                         lock("katsdpingest-autotune-${env.BRANCH_NAME}") {

--- a/jenkins-autotune.sh
+++ b/jenkins-autotune.sh
@@ -15,5 +15,13 @@ COPY_FROM="$DOCKER_REGISTRY/katsdpingest_$GPU:latest"
 install_pinned.py -r requirements-autotune.txt
 docker pull "$BASE_IMAGE"
 docker pull "$COPY_FROM"
+trap "docker rmi $IMAGE" EXIT
 scripts/autotune_mkimage.py -H $DOCKER_HOST --tls --copy --copy-from "$COPY_FROM" "$IMAGE" "$BASE_IMAGE"
 docker push "$IMAGE"
+
+if [ -n "$DOCKER_REGISTRY2" ]; then
+    IMAGE2="$DOCKER_REGISTRY2/katsdpingest_$GPU:$LABEL"
+    trap "docker rmi $IMAGE2" EXIT
+    docker tag "$IMAGE" "$IMAGE2"
+    docker push "$IMAGE2"
+fi


### PR DESCRIPTION
For now the image is pushed to both Harbor (a.k.a. DOCKER_REGISTRY2) while still falling back to pushing to DOCKER_REGISTRY.

I also added a `trap` command to ensure the images are deleted after pushing, to avoid filling up the disk so quickly.

Relates to SPR1-200.