### PR TITLE
SPR1-3030: Remove `--input-max-packet-size` option

### DIFF
--- a/katsdpingest/ingest_session.py
+++ b/katsdpingest/ingest_session.py
@@ -1107,7 +1107,6 @@ class CBFIngest:
         self.rx_spead_ifaddr = katsdpservices.get_interface_address(args.cbf_interface)
         self.rx_spead_ibv: bool = args.cbf_ibv
         self.rx_spead_max_streams: int = args.input_streams
-        self.rx_spead_max_packet_size: int = args.input_max_packet_size
         self.rx_spead_buffer_size: int = args.input_buffer
         self.sd_spead_rate: float = (
             args.sd_spead_rate / args.clock_ratio if args.clock_ratio else 0.0
@@ -1763,7 +1762,6 @@ class CBFIngest:
         self.rx = TelstateReceiver(
             self.rx_spead_endpoints, self.rx_spead_ifaddr, self.rx_spead_ibv,
             self.rx_spead_max_streams,
-            max_packet_size=self.rx_spead_max_packet_size,
             buffer_size=self.rx_spead_buffer_size,
             channel_range=self.channel_ranges.subscribed,
             cbf_channels=len(self.channel_ranges.cbf),

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -52,7 +52,7 @@ class MockReceiver:
     """
     def __init__(self, data, timestamps,
                  endpoints, interface_address, ibv,
-                 max_streams, max_packet_size, buffer_size,
+                 max_streams, buffer_size,
                  channel_range, cbf_channels, sensors,
                  cbf_attr, active_frames=2, telstates=None,
                  l0_int_time=None, pauses=None):
@@ -223,7 +223,6 @@ class TestIngestDeviceServer(asynctest.TestCase):
             sd_continuum_factor=128,
             guard_channels=64,
             input_streams=2,
-            input_max_packet_size=9200,
             input_buffer=32*1024**2,
             sd_spead_rate=1000000000.0,
             excise=False,

--- a/katsdpingest/test/test_receiver.py
+++ b/katsdpingest/test/test_receiver.py
@@ -49,7 +49,7 @@ class TestReceiver(asynctest.TestCase):
             # asyncio.iscoroutinefunction doesn't like pybind11 functions, so
             # we have to hide it inside a lambda.
             self.addCleanup(lambda: tx.queues[0].stop())
-        self.rx = Receiver(endpoints, '127.0.0.1', False, self.n_streams, 9200, 32 * 1024**2,
+        self.rx = Receiver(endpoints, '127.0.0.1', False, self.n_streams, 32 * 1024**2,
                            Range(0, self.n_chans), self.n_chans,
                            sensors, self.cbf_attr, active_frames=3)
         self.tx_ig = [spead2.send.ItemGroup() for tx in self.tx]

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -105,9 +105,6 @@ def parse_args() -> argparse.Namespace:
         '--input-streams', default=1, type=int,
         help='maximum separate streams for receive. [default=%(default)s]')
     parser.add_argument(
-        '--input-max-packet-size', default=4608, type=int,
-        help='maximum packet size to receive. [default=[%(default)s]')
-    parser.add_argument(
         '--input-buffer', default=64 * 1024**2, type=int,
         help='network buffer size ofr input. [default=%(default)s]')
     parser.add_argument(

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -106,7 +106,7 @@ def parse_args() -> argparse.Namespace:
         help='maximum separate streams for receive. [default=%(default)s]')
     parser.add_argument(
         '--input-buffer', default=64 * 1024**2, type=int,
-        help='network buffer size ofr input. [default=%(default)s]')
+        help='network buffer size for input. [default=%(default)s]')
     parser.add_argument(
         '--sd-spead-rate', type=float, default=1000000000,
         help='rate (bits per second) to transmit signal display output. [default=%(default)s]')


### PR DESCRIPTION

PR #206 (and specifically commit bebf643d) reduced the input packet size of the MeerKAT ingest receivers from 9200 to 4608 via the `--input-max-packet-size` script option, but we had to go back up to 9200 during the MeerKAT+ lab integration tests to get any SPEAD data into ingest (to avoid truncated packets).

Quoting Bruce:

> I think that was because the CX-3's [LS: Connect-X 3 NICs] we used
> initially performed poorly when the max packet size was much bigger
> than the actual packet size (and also spead2 wasn't as optimised as
> it is these days). I think it should be safe to just rip out the
> input-max-packet-size option and everything downstream of it, and use
> spead2's default max packet size.

So this largely undoes #206.