### PR TITLE
SPR1-2373: Flag MK+ visibility values of -2**31 as DATA_LOST

### DIFF
--- a/katsdpingest/ingest_kernels/postproc.mako
+++ b/katsdpingest/ingest_kernels/postproc.mako
@@ -60,7 +60,7 @@ KERNEL REQD_WORK_GROUP_SIZE(${wgsx}, ${wgsy}, 1) void postproc(
         GLOBAL float *wptr = &weights[addr];
         float w = *wptr;
         GLOBAL unsigned char *fptr = &flags[addr];
-        unsigned char f = *fptr;
+        unsigned char __attribute__((unused)) f = *fptr;  // only for continuum or excise
 % if continuum:
         cv.x += v.x;
         cv.y += v.y;

--- a/katsdpingest/ingest_kernels/prepare.mako
+++ b/katsdpingest/ingest_kernels/prepare.mako
@@ -20,7 +20,7 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare(
     /* Load values into shared memory, applying the type conversion and
      * scaling. The input array is padded, so no range checks are needed.
      *
-     * The GPU CBF indicates missing data by setting the real int32 value to -2**31.
+     * The GPU CBF indicates missing data by setting the real int32 value to INT_MIN.
      * Convert these to negative zero floats instead. This treats missing visibilities
      * as zeros like in the old CBF, while still allowing them to be flagged
      * differently in prepare_flags by checking their sign bits.
@@ -28,7 +28,7 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare(
     <%transpose:transpose_load coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
         int2 in_value = vis_in[${r} * vis_in_stride + ${c}];
         float2 scaled_value;
-        if (in_value.x == -1 << 31)
+        if (in_value.x == INT_MIN)
         {
             scaled_value.x = -0.0f;
             scaled_value.y = 0.0f;

--- a/katsdpingest/ingest_kernels/prepare.mako
+++ b/katsdpingest/ingest_kernels/prepare.mako
@@ -19,12 +19,20 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare(
 
     /* Load values into shared memory, applying the type conversion and
      * scaling. The input array is padded, so no range checks are needed.
+     * CBF indicates missing data by setting the real int32 value to -2**31.
+     * Convert these to NaNs instead in order to flag them in prepare_flags.
      */
     <%transpose:transpose_load coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
         int2 in_value = vis_in[${r} * vis_in_stride + ${c}];
         float2 scaled_value;
-        scaled_value.x = (float) in_value.x * scale;
-        scaled_value.y = (float) in_value.y * scale;
+        if (in_value.x == -1 << 31)
+        {
+            scaled_value.x = NAN;
+            scaled_value.y = NAN;
+        } else {
+            scaled_value.x = (float) in_value.x * scale;
+            scaled_value.y = (float) in_value.y * scale;
+        }
         values.arr[${lr}][${lc}] = scaled_value;
     </%transpose:transpose_load>
 

--- a/katsdpingest/ingest_kernels/prepare.mako
+++ b/katsdpingest/ingest_kernels/prepare.mako
@@ -19,16 +19,19 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare(
 
     /* Load values into shared memory, applying the type conversion and
      * scaling. The input array is padded, so no range checks are needed.
-     * CBF indicates missing data by setting the real int32 value to -2**31.
-     * Convert these to NaNs instead in order to flag them in prepare_flags.
+     *
+     * The GPU CBF indicates missing data by setting the real int32 value to -2**31.
+     * Convert these to negative zero floats instead. This treats missing visibilities
+     * as zeros like in the old CBF, while still allowing them to be flagged
+     * differently in prepare_flags by checking their sign bits.
      */
     <%transpose:transpose_load coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
         int2 in_value = vis_in[${r} * vis_in_stride + ${c}];
         float2 scaled_value;
         if (in_value.x == -1 << 31)
         {
-            scaled_value.x = NAN;
-            scaled_value.y = NAN;
+            scaled_value.x = -0.0f;
+            scaled_value.y = 0.0f;
         } else {
             scaled_value.x = (float) in_value.x * scale;
             scaled_value.y = (float) in_value.y * scale;

--- a/katsdpingest/ingest_kernels/prepare_flags.mako
+++ b/katsdpingest/ingest_kernels/prepare_flags.mako
@@ -13,7 +13,8 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
     int vis_stride,
     int channel_mask_stride,
     uint max_mask,
-    uchar zero_flag)
+    uchar zero_flag,
+    uchar missing_flag)
 {
     LOCAL_DECL transpose_flags local_flags;
     transpose_coords coords;
@@ -34,6 +35,8 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
         float2 v = vis[${r} * vis_stride + ${c}];
         if (v.x == 0 && v.y == 0)
             f |= zero_flag;
+        else if (v.x == -2147483600.0f)   // -2 ** 31 as a float32
+            f |= missing_flag;
         flags[addr] = f;
     </%transpose:transpose_store>
 }

--- a/katsdpingest/ingest_kernels/prepare_flags.mako
+++ b/katsdpingest/ingest_kernels/prepare_flags.mako
@@ -6,7 +6,7 @@
 
 KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
     GLOBAL uchar * RESTRICT flags,
-    GLOBAL float2 * RESTRICT vis,
+    const GLOBAL float2 * RESTRICT vis,
     const GLOBAL uchar * RESTRICT channel_mask,
     const GLOBAL uint * RESTRICT channel_mask_idx,
     int flags_stride,
@@ -30,22 +30,16 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
 
     // Write flags back to global memory in channel-major order
     <%transpose:transpose_store coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
-        int flags_addr = ${r} * flags_stride + ${c};
-        int vis_addr = ${r} * vis_stride + ${c};
+        int addr = ${r} * flags_stride + ${c};
         uchar f = local_flags.arr[${lr}][${lc}];
-        float2 v = vis[vis_addr];
-        // Flag zero visibilities
-        if (v.x == 0.0f && v.y == 0.0f)
-            f |= zero_flag;
-        // Flag missing visibilities and zero them afterwards
-        else if (isnan(v.x) || isnan(v.y))
+        float2 v = vis[${r} * vis_stride + ${c}];
+        if (v.x == 0 && v.y == 0)
         {
-            f |= missing_flag;
-            float2 zero_vis;
-            zero_vis.x = 0.0f;
-            zero_vis.y = 0.0f;
-            vis[vis_addr] = zero_vis;
+            f |= zero_flag;
+            // This indicates that the GPU CBF stream had missing data
+            if (signbit(v.x))
+                f |= missing_flag;
         }
-        flags[flags_addr] = f;
+        flags[addr] = f;
     </%transpose:transpose_store>
 }

--- a/katsdpingest/ingest_kernels/prepare_flags.mako
+++ b/katsdpingest/ingest_kernels/prepare_flags.mako
@@ -6,7 +6,7 @@
 
 KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
     GLOBAL uchar * RESTRICT flags,
-    const GLOBAL float2 * RESTRICT vis,
+    GLOBAL float2 * RESTRICT vis,
     const GLOBAL uchar * RESTRICT channel_mask,
     const GLOBAL uint * RESTRICT channel_mask_idx,
     int flags_stride,
@@ -30,13 +30,22 @@ KERNEL REQD_WORK_GROUP_SIZE(${block}, ${block}, 1) void prepare_flags(
 
     // Write flags back to global memory in channel-major order
     <%transpose:transpose_store coords="coords" block="${block}" vtx="${vtx}" vty="${vty}" args="r, c, lr, lc">
-        int addr = ${r} * flags_stride + ${c};
+        int flags_addr = ${r} * flags_stride + ${c};
+        int vis_addr = ${r} * vis_stride + ${c};
         uchar f = local_flags.arr[${lr}][${lc}];
-        float2 v = vis[${r} * vis_stride + ${c}];
-        if (v.x == 0 && v.y == 0)
+        float2 v = vis[vis_addr];
+        // Flag zero visibilities
+        if (v.x == 0.0f && v.y == 0.0f)
             f |= zero_flag;
-        else if (v.x == -2147483600.0f)   // -2 ** 31 as a float32
+        // Flag missing visibilities and zero them afterwards
+        else if (isnan(v.x) || isnan(v.y))
+        {
             f |= missing_flag;
-        flags[addr] = f;
+            float2 zero_vis;
+            zero_vis.x = 0.0f;
+            zero_vis.y = 0.0f;
+            vis[vis_addr] = zero_vis;
+        }
+        flags[flags_addr] = f;
     </%transpose:transpose_store>
 }

--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -7,7 +7,7 @@ import numpy as np
 from katsdpsigproc import accel, tune, fill, transpose, percentile, maskedsum, reduce
 import katsdpsigproc.rfi.device
 from katsdpsigproc.abc import AbstractContext, AbstractCommandQueue
-from katdal.flags import CAL_RFI, CAM
+from katdal.flags import CAL_RFI, CAM, DATA_LOST
 
 from .utils import Range
 
@@ -196,12 +196,13 @@ class Prepare(accel.Operation):
 
 
 class PrepareFlagsTemplate:
-    """Generate initial per-visibility flags from CAM sensor data.
+    """Generate initial per-visibility flags from CAM sensor and vis data.
 
     Given a collection of channel masks and a per-baseline index of which
     mask to apply, constructs per-visibility static flags. It also flags
     visibilities which are zero (since this is assumed to always be a sign
-    of a problem in the correlator).
+    of a problem in the correlator) and visibilities which are marked as
+    missing in the correlator.
 
     Parameters
     ----------
@@ -251,7 +252,7 @@ class PrepareFlagsTemplate:
             fn = cls(context, {
                 'block': block,
                 'vtx': vtx,
-                'vty': vty}).instantiate(queue, channels, baselines, masks, CAM)
+                'vty': vty}).instantiate(queue, channels, baselines, masks, CAM, DATA_LOST)
             fn.bind(flags=flags, channel_mask=channel_mask, channel_mask_idx=channel_mask_idx)
             return tune.make_measure(queue, fn)
         return tune.autotune(
@@ -261,8 +262,10 @@ class PrepareFlagsTemplate:
             vty=[1, 2, 3, 4])
 
     def instantiate(self, command_queue: AbstractCommandQueue,
-                    channels: int, baselines: int, masks: int, zero_flag: int) -> 'PrepareFlags':
-        return PrepareFlags(self, command_queue, channels, baselines, masks, zero_flag)
+                    channels: int, baselines: int, masks: int,
+                    zero_flag: int, missing_flag: int) -> 'PrepareFlags':
+        return PrepareFlags(self, command_queue, channels, baselines, masks,
+                            zero_flag, missing_flag)
 
 
 class PrepareFlags(accel.Operation):
@@ -293,16 +296,20 @@ class PrepareFlags(accel.Operation):
         Number of masks in **channel_masks**
     zero_flag
         Flag value to merge in to flags for zero visibilities
+    missing_flag
+        Flag value to merge in to flags for visibilities marked as missing
     """
     def __init__(self, template: PrepareFlagsTemplate,
                  command_queue: AbstractCommandQueue,
-                 channels: int, baselines: int, masks: int, zero_flag: int) -> None:
+                 channels: int, baselines: int, masks: int,
+                 zero_flag: int, missing_flag: int) -> None:
         super().__init__(command_queue)
         self.template = template
         self.channels = channels
         self.baselines = baselines
         self.masks = masks
         self.zero_flag = zero_flag
+        self.missing_flag = missing_flag
         tilex = template.block * template.vtx
         tiley = template.block * template.vty
 
@@ -341,7 +348,8 @@ class PrepareFlags(accel.Operation):
                 np.int32(vis.padded_shape[1]),
                 np.int32(channel_mask.padded_shape[1]),
                 np.uint32(self.masks - 1),
-                np.uint8(self.zero_flag)
+                np.uint8(self.zero_flag),
+                np.uint8(self.missing_flag)
             ],
             global_size=(xblocks * block, yblocks * block),
             local_size=(block, block))
@@ -351,7 +359,8 @@ class PrepareFlags(accel.Operation):
             'channels': self.channels,
             'baselines': self.baselines,
             'masks': self.masks,
-            'zero_flag': self.zero_flag
+            'zero_flag': self.zero_flag,
+            'missing_flag': self.missing_flag
         }
 
 
@@ -1438,7 +1447,7 @@ class IngestOperation(accel.OperationSequence):
         self.prepare = template.prepare.instantiate(
             command_queue, channels, cbf_baselines, baselines)
         self.prepare_flags = template.prepare_flags.instantiate(
-            command_queue, channels, baselines, masks, CAM)
+            command_queue, channels, baselines, masks, CAM, DATA_LOST)
         self.init_weights = template.init_weights.instantiate(
             command_queue, (baselines, kept_channels))
         self.zero_spec = Zero(command_queue, kept_channels, baselines)

--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -36,7 +36,7 @@ class Zero(accel.Operation):
 class PrepareTemplate:
     """Handles first-stage data processing on a compute device:
 
-    - Conversion to floating point
+    - Conversion to floating point (zeroing the GPU CBF's missing data markers)
     - Scaling
     - Transposition
     - Baseline reordering
@@ -201,8 +201,7 @@ class PrepareFlagsTemplate:
     Given a collection of channel masks and a per-baseline index of which
     mask to apply, constructs per-visibility static flags. It also flags
     visibilities which are zero (since this is assumed to always be a sign
-    of a problem in the correlator) and visibilities which are marked as
-    missing in the correlator, zeroing them afterwards.
+    of a problem in the correlator).
 
     Parameters
     ----------
@@ -274,7 +273,7 @@ class PrepareFlags(accel.Operation):
     .. rubric:: Slots
 
     **vis** : channels × baselines, complex64
-        Input visibilities (output from :class:`Prepare`, *may be modified*)
+        Input visibilities (output from :class:`Prepare`)
     **flags** : channels × baselines, uint8
         Output channels
     **channel_mask** : masks × channels, uint8

--- a/katsdpingest/sigproc.py
+++ b/katsdpingest/sigproc.py
@@ -196,13 +196,13 @@ class Prepare(accel.Operation):
 
 
 class PrepareFlagsTemplate:
-    """Generate initial per-visibility flags from CAM sensor and vis data.
+    """Generate initial per-visibility flags from CAM sensors and vis data.
 
     Given a collection of channel masks and a per-baseline index of which
     mask to apply, constructs per-visibility static flags. It also flags
     visibilities which are zero (since this is assumed to always be a sign
     of a problem in the correlator) and visibilities which are marked as
-    missing in the correlator.
+    missing in the correlator, zeroing them afterwards.
 
     Parameters
     ----------
@@ -274,7 +274,7 @@ class PrepareFlags(accel.Operation):
     .. rubric:: Slots
 
     **vis** : channels × baselines, complex64
-        Input visibilities (output from :class:`Prepare`)
+        Input visibilities (output from :class:`Prepare`, *may be modified*)
     **flags** : channels × baselines, uint8
         Output channels
     **channel_mask** : masks × channels, uint8

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -21,7 +21,7 @@ import aiokatcp
 import katsdptelstate.aio
 from katsdptelstate.endpoint import Endpoint
 from katsdpsigproc.test.test_accel import device_test
-from katdal.flags import CAM, STATIC
+from katdal.flags import CAM, STATIC, DATA_LOST
 import katsdpmodels.rfi_mask
 import katsdpmodels.band_mask
 import katpoint
@@ -149,7 +149,8 @@ class TestIngestDeviceServer(asynctest.TestCase):
         start_ts = 100000000
         interval = self.cbf_attr['n_accs'] * self.cbf_attr['ticks_between_spectra']
         n_dumps = 19
-        shape = (n_dumps, self.cbf_attr['n_chans'], len(self.cbf_attr['bls_ordering']), 2)
+        n_chans = self.cbf_attr['n_chans']
+        shape = (n_dumps, n_chans, len(self.cbf_attr['bls_ordering']), 2)
         rs = np.random.RandomState(seed=1)
         data = (rs.standard_normal(shape) * 1000).astype(np.int32)
         # Make autocorrelations real, and also set a fixed value. This gives
@@ -159,6 +160,11 @@ class TestIngestDeviceServer(asynctest.TestCase):
             if a == b:
                 data[:, :, i, 0] = 1000
                 data[:, :, i, 1] = 0
+        # Make the last dump disappear, testing both the old and new way interleaved
+        data[-1, 0::2, :, 0] = 0
+        data[-1, 0::2, :, 1] = 0
+        data[-1, 1::2, :, 0] = -2 ** 31
+        data[-1, 1::2, :, 1] = 1
         timestamps = (np.arange(n_dumps) * interval + start_ts).astype(np.uint64)
         return data, timestamps
 
@@ -359,13 +365,21 @@ class TestIngestDeviceServer(asynctest.TestCase):
         channel_mask[820:840] = True     # Merge in band mask
         channel_data_suspect = self.fake_channel_data_suspect()[np.newaxis, :, np.newaxis]
         flags[:] = channel_data_suspect * np.uint8(CAM)
+        # Flag missing data (old MK style)
+        old_missing = (self._data[:, :, inv_permutation] == 0).all(axis=-1)
+        old_missing = np.logical_or.reduceat(old_missing, batch_edges, axis=0)
+        flags[old_missing] |= np.uint8(CAM)
+        # Flag missing data (new MK+ style)
+        new_missing = self._data[:, :, inv_permutation, 0] == -2**31
+        new_missing = np.logical_or.reduceat(new_missing, batch_edges, axis=0)
+        flags[new_missing] |= np.uint8(DATA_LOST)
         for i, (a, b) in enumerate(bls.sdp_bls_ordering):
             if a.startswith('m091') or b.startswith('m091'):
                 # data suspect sensor is True
-                flags[:, :, i] |= CAM
+                flags[:, :, i] |= np.uint8(CAM)
             if a == 'm090v' or b == 'm090v':
                 # input_data_suspect is True
-                flags[:, :, i] |= CAM
+                flags[:, :, i] |= np.uint8(CAM)
             flags[:, :, i] |= channel_mask * np.uint8(STATIC)
             if a[:-1] != b[:-1]:
                 # RFI model, which doesn't apply to auto-correlations

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -18,7 +18,7 @@ import spead2
 import spead2.recv
 import spead2.send
 import aiokatcp
-import katsdptelstate.aio.memory
+import katsdptelstate.aio
 from katsdptelstate.endpoint import Endpoint
 from katsdpsigproc.test.test_accel import device_test
 from katdal.flags import CAM, STATIC
@@ -55,7 +55,7 @@ class MockReceiver:
                  max_streams, buffer_size,
                  channel_range, cbf_channels, sensors,
                  cbf_attr, active_frames=2, telstates=None,
-                 l0_int_time=None, pauses=None):
+                 l0_int_time=None, pauses=None) -> None:
         assert data.shape[0] == len(timestamps)
         self._next_frame = 0
         self._data = data
@@ -69,19 +69,17 @@ class MockReceiver:
         self.interval = cbf_attr['ticks_between_spectra'] * cbf_attr['n_accs']
         self.timestamp_base = timestamps[0]
 
-    def stop(self):
+    def stop(self) -> None:
         self._stop_event.set()
 
-    @asyncio.coroutine
-    def join(self):
-        yield from(self._stop_event.wait())
+    async def join(self) -> None:
+        await self._stop_event.wait()
 
-    @asyncio.coroutine
-    def get(self):
+    async def get(self) -> Frame:
         event = self._pauses.get(self._next_frame)
         if event is None:
             event = asyncio.sleep(0)
-        yield from(event)
+        await event
         if self._next_frame >= len(self._data):
             raise spead2.Stopped('end of frame list')
         frame = Frame(self._next_frame, self._timestamps[self._next_frame], self._substreams)

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -36,6 +36,9 @@ from katsdpingest.receiver import Frame
 from katsdpingest.sender import Data
 
 
+INT_MIN = np.iinfo(np.int32).min
+
+
 class MockReceiver:
     """Replacement for :class:`katsdpingest.receiver.Receiver`.
 
@@ -162,7 +165,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         # Make the last dump disappear, testing both the old and new way interleaved
         data[-1, 0::2, :, 0] = 0
         data[-1, 0::2, :, 1] = 0
-        data[-1, 1::2, :, 0] = -2 ** 31
+        data[-1, 1::2, :, 0] = INT_MIN
         data[-1, 1::2, :, 1] = 1
         timestamps = (np.arange(n_dumps) * interval + start_ts).astype(np.uint64)
         return data, timestamps
@@ -338,7 +341,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         # Convert to complex64 from pairs of real and imag int
         vis = (self._data[..., 0] + self._data[..., 1] * 1j).astype(np.complex64)
         # Expect any missing visibilities to be zero
-        vis[self._data[..., 0] == -2**31] = 0.0
+        vis[self._data[..., 0] == INT_MIN] = 0.0
         # Scaling
         vis /= self.cbf_attr['n_accs']
         # Time averaging
@@ -371,7 +374,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         old_missing = np.logical_or.reduceat(old_missing, batch_edges, axis=0)
         flags[old_missing] |= np.uint8(CAM)
         # Flag missing data (new MK+ style, also zero in the end...)
-        new_missing = self._data[:, :, inv_permutation, 0] == -2**31
+        new_missing = self._data[:, :, inv_permutation, 0] == INT_MIN
         new_missing = np.logical_or.reduceat(new_missing, batch_edges, axis=0)
         flags[new_missing] |= np.uint8(CAM)
         flags[new_missing] |= np.uint8(DATA_LOST)

--- a/katsdpingest/test/test_ingest_server.py
+++ b/katsdpingest/test/test_ingest_server.py
@@ -149,8 +149,7 @@ class TestIngestDeviceServer(asynctest.TestCase):
         start_ts = 100000000
         interval = self.cbf_attr['n_accs'] * self.cbf_attr['ticks_between_spectra']
         n_dumps = 19
-        n_chans = self.cbf_attr['n_chans']
-        shape = (n_dumps, n_chans, len(self.cbf_attr['bls_ordering']), 2)
+        shape = (n_dumps, self.cbf_attr['n_chans'], len(self.cbf_attr['bls_ordering']), 2)
         rs = np.random.RandomState(seed=1)
         data = (rs.standard_normal(shape) * 1000).astype(np.int32)
         # Make autocorrelations real, and also set a fixed value. This gives
@@ -338,6 +337,8 @@ class TestIngestDeviceServer(asynctest.TestCase):
         """
         # Convert to complex64 from pairs of real and imag int
         vis = (self._data[..., 0] + self._data[..., 1] * 1j).astype(np.complex64)
+        # Expect any missing visibilities to be zero
+        vis[self._data[..., 0] == -2**31] = 0.0
         # Scaling
         vis /= self.cbf_attr['n_accs']
         # Time averaging
@@ -369,9 +370,10 @@ class TestIngestDeviceServer(asynctest.TestCase):
         old_missing = (self._data[:, :, inv_permutation] == 0).all(axis=-1)
         old_missing = np.logical_or.reduceat(old_missing, batch_edges, axis=0)
         flags[old_missing] |= np.uint8(CAM)
-        # Flag missing data (new MK+ style)
+        # Flag missing data (new MK+ style, also zero in the end...)
         new_missing = self._data[:, :, inv_permutation, 0] == -2**31
         new_missing = np.logical_or.reduceat(new_missing, batch_edges, axis=0)
+        flags[new_missing] |= np.uint8(CAM)
         flags[new_missing] |= np.uint8(DATA_LOST)
         for i, (a, b) in enumerate(bls.sdp_bls_ordering):
             if a.startswith('m091') or b.startswith('m091'):

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -18,7 +18,7 @@ from katsdpingest.utils import Range
 UNFLAGGED_BIT = 128
 FLAG_SCALE = np.float32(2) ** -64
 FLAG_SCALE_INV = np.float32(2) ** 64
-MISSING = np.complex64(-2 ** 31 + 1j)
+NAN = np.complex64(np.nan + 1j * np.nan)
 
 
 def random_vis(rs, shape):
@@ -53,12 +53,16 @@ class TestPrepare:
     def test_prepare(self, context, queue):
         """Basic test of data preparation"""
         channels = 73
+        channels_missing_data = 5
         in_baselines = 99
         out_baselines = 91
         n_accs = 11
 
         rs = np.random.RandomState(seed=1)
         vis_in = rs.random_integers(-1000, 1000, (channels, in_baselines, 2)).astype(np.int32)
+        # Mark the data in the first few channels as missing
+        vis_in[:channels_missing_data, :, 0] = -2 ** 31
+        vis_in[:channels_missing_data, :, 1] = 1
         permutation = rs.permutation(in_baselines).astype(np.int16)
         permutation[permutation >= out_baselines] = -1
 
@@ -73,8 +77,9 @@ class TestPrepare:
 
         assert_equal((out_baselines, channels), vis_out.shape)
         expected_vis = np.zeros_like(vis_out)
+        expected_vis[:, :channels_missing_data] = NAN
         scale = np.float32(1 / n_accs)
-        for i in range(channels):
+        for i in range(channels_missing_data, channels):
             for j in range(in_baselines):
                 value = (vis_in[i, j, 0] + 1j * vis_in[i, j, 1]) * scale
                 row = permutation[j]
@@ -101,7 +106,7 @@ class TestPrepareFlags:
         vis = random_vis(rs, (channels, baselines))
         # Create some zero and marked visibilities to ensure they're flagged
         vis[rs.rand(channels, baselines) < 0.3] = 0
-        vis[rs.rand(channels, baselines) < 0.1] = MISSING
+        vis[rs.rand(channels, baselines) < 0.1] = NAN
         channel_mask = random_flags(rs, (masks, channels), 7, 0.1)
         channel_mask_idx = rs.randint(0, masks, baselines).astype(np.uint32)
 
@@ -113,11 +118,15 @@ class TestPrepareFlags:
         fn.buffer('channel_mask_idx').set(queue, channel_mask_idx)
         fn()
         flags = fn.buffer('flags').get(queue)
+        vis_out = fn.buffer('vis').get(queue)
 
         expected = channel_mask[channel_mask_idx, :].T
         expected = expected | np.where(vis == 0, 2**6, 0)
-        expected = expected | np.where(vis == MISSING, 2**7, 0)
+        expected = expected | np.where(np.isnan(vis), 2**7, 0)
         np.testing.assert_equal(expected, flags)
+        expected_vis = vis.copy()
+        expected_vis[np.isnan(vis)] = 0 + 0j
+        np.testing.assert_equal(expected_vis, vis_out)
 
 
 class TestMergeFlags:

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -18,7 +18,6 @@ from katsdpingest.utils import Range
 UNFLAGGED_BIT = 128
 FLAG_SCALE = np.float32(2) ** -64
 FLAG_SCALE_INV = np.float32(2) ** 64
-NAN = np.complex64(np.nan + 1j * np.nan)
 
 
 def random_vis(rs, shape):
@@ -77,7 +76,6 @@ class TestPrepare:
 
         assert_equal((out_baselines, channels), vis_out.shape)
         expected_vis = np.zeros_like(vis_out)
-        expected_vis[:, :channels_missing_data] = NAN
         scale = np.float32(1 / n_accs)
         for i in range(channels_missing_data, channels):
             for j in range(in_baselines):
@@ -86,6 +84,8 @@ class TestPrepare:
                 if row >= 0:
                     expected_vis[row, i] = value
         np.testing.assert_equal(expected_vis, vis_out)
+        missing_reals_are_negative = np.signbit(vis_out[:, :channels_missing_data].real)
+        np.testing.assert_equal(missing_reals_are_negative, True)
 
     @device_test
     @force_autotune
@@ -104,9 +104,9 @@ class TestPrepareFlags:
         masks = 17
         rs = np.random.RandomState(seed=1)
         vis = random_vis(rs, (channels, baselines))
-        # Create some zero and marked visibilities to ensure they're flagged
-        vis[rs.rand(channels, baselines) < 0.3] = 0
-        vis[rs.rand(channels, baselines) < 0.1] = NAN
+        # Create some zero and missing visibilities to ensure they're flagged
+        vis[rs.rand(channels, baselines) < 0.3] = 0.0
+        vis[rs.rand(channels, baselines) < 0.1] = -0.0
         channel_mask = random_flags(rs, (masks, channels), 7, 0.1)
         channel_mask_idx = rs.randint(0, masks, baselines).astype(np.uint32)
 
@@ -118,15 +118,11 @@ class TestPrepareFlags:
         fn.buffer('channel_mask_idx').set(queue, channel_mask_idx)
         fn()
         flags = fn.buffer('flags').get(queue)
-        vis_out = fn.buffer('vis').get(queue)
 
         expected = channel_mask[channel_mask_idx, :].T
         expected = expected | np.where(vis == 0, 2**6, 0)
-        expected = expected | np.where(np.isnan(vis), 2**7, 0)
+        expected = expected | np.where((vis == 0) & np.signbit(vis.real), 2**7, 0)
         np.testing.assert_equal(expected, flags)
-        expected_vis = vis.copy()
-        expected_vis[np.isnan(vis)] = 0 + 0j
-        np.testing.assert_equal(expected_vis, vis_out)
 
 
 class TestMergeFlags:

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -18,6 +18,7 @@ from katsdpingest.utils import Range
 UNFLAGGED_BIT = 128
 FLAG_SCALE = np.float32(2) ** -64
 FLAG_SCALE_INV = np.float32(2) ** 64
+INT_MIN = np.iinfo(np.int32).min
 
 
 def random_vis(rs, shape):
@@ -60,7 +61,7 @@ class TestPrepare:
         rs = np.random.RandomState(seed=1)
         vis_in = rs.random_integers(-1000, 1000, (channels, in_baselines, 2)).astype(np.int32)
         # Mark the data in the first few channels as missing
-        vis_in[:channels_missing_data, :, 0] = -2 ** 31
+        vis_in[:channels_missing_data, :, 0] = INT_MIN
         vis_in[:channels_missing_data, :, 1] = 1
         permutation = rs.permutation(in_baselines).astype(np.int16)
         permutation[permutation >= out_baselines] = -1

--- a/katsdpingest/test/test_sigproc.py
+++ b/katsdpingest/test/test_sigproc.py
@@ -8,7 +8,7 @@ from katsdpsigproc import tune
 import katsdpsigproc.rfi.device as rfi
 import katsdpsigproc.rfi.host as rfi_host
 from katsdpsigproc.test.test_accel import device_test, force_autotune
-from katdal.flags import INGEST_RFI, CAL_RFI, CAM
+from katdal.flags import INGEST_RFI, CAL_RFI, CAM, DATA_LOST
 from nose.tools import assert_equal, assert_raises
 
 from katsdpingest import sigproc
@@ -18,6 +18,7 @@ from katsdpingest.utils import Range
 UNFLAGGED_BIT = 128
 FLAG_SCALE = np.float32(2) ** -64
 FLAG_SCALE_INV = np.float32(2) ** 64
+MISSING = np.complex64(-2 ** 31 + 1j)
 
 
 def random_vis(rs, shape):
@@ -98,13 +99,14 @@ class TestPrepareFlags:
         masks = 17
         rs = np.random.RandomState(seed=1)
         vis = random_vis(rs, (channels, baselines))
-        # Create some zero visibilities to ensure they're flagged
+        # Create some zero and marked visibilities to ensure they're flagged
         vis[rs.rand(channels, baselines) < 0.3] = 0
+        vis[rs.rand(channels, baselines) < 0.1] = MISSING
         channel_mask = random_flags(rs, (masks, channels), 7, 0.1)
         channel_mask_idx = rs.randint(0, masks, baselines).astype(np.uint32)
 
         template = sigproc.PrepareFlagsTemplate(context)
-        fn = template.instantiate(queue, channels, baselines, masks, 2**7)
+        fn = template.instantiate(queue, channels, baselines, masks, 2**6, 2**7)
         fn.ensure_all_bound()
         fn.buffer('vis').set(queue, vis)
         fn.buffer('channel_mask').set(queue, channel_mask)
@@ -113,7 +115,8 @@ class TestPrepareFlags:
         flags = fn.buffer('flags').get(queue)
 
         expected = channel_mask[channel_mask_idx, :].T
-        expected = expected | np.where(vis == 0, 2**7, 0)
+        expected = expected | np.where(vis == 0, 2**6, 0)
+        expected = expected | np.where(vis == MISSING, 2**7, 0)
         np.testing.assert_equal(expected, flags)
 
 
@@ -480,7 +483,7 @@ class TestIngestOperation:
             ('ingest:prepare_flags', {
                 'baselines': 192, 'channels': 128,
                 'class': 'katsdpingest.sigproc.PrepareFlags',
-                'masks': 3, 'zero_flag': CAM
+                'masks': 3, 'zero_flag': CAM, 'missing_flag': DATA_LOST
             }),
             ('ingest:init_weights', {
                 'class': 'katsdpsigproc.fill.Fill', 'shape': (192, 80),


### PR DESCRIPTION
The next-generation correlator for MK+ indicates missing F-engine heaps by setting the corresponding correlation products in the X-engine to `-2 ** 31 + 1j`, whereas the old MK correlator set those to `0 + 0j`. Flag these values as `DATA_LOST`, which is more specific than the `CAM` flag used to flag zeroes in general.

The special value of `-2 ** 31` (aka the *missing data marker*) is unambiguous since it is outside the valid range of values in both the old and new correlators. The new correlator prefers this value to 0 because that makes 0 a valid value that can be used to check corner cases in its unit tests.

For now we keep on flagging zeros as `CAM` in MK+, since this would ensure continuity and still be an unlikely value in proper science operations. We also zero visibilities with the special value after flagging, in case it leaks through to folks who disregard flags, and flag it as `CAM` as well for good measure.

I used the opportunity to fix some technical debt too... There is a large overhead to PRs and by the time I get around to a technical debt PR, I would have to rediscover what I now know.

I now use negative zeros to distinguish missing data from plain zeros in the intermediate visibility product in the ingest pipeline, which maintains backward compatibility while also allowing more specific flagging.